### PR TITLE
Fixes typo: teel -> tell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Features
 
     'hackport status [toportage]'
         Provides an overview comparing the overlay to the portage tree.
-        It will teel you, for each package and version, if the package exist
+        It will tell you, for each package and version, if the package exist
 
             - only in the portage tree
             - only in the overlay


### PR DESCRIPTION
As the title says, this fixes a typo found in the README.rst on line 107. 