### PR TITLE
Update Gentoo Foundation to Gentoo Authors

### DIFF
--- a/Portage/EBuild.hs
+++ b/Portage/EBuild.hs
@@ -91,7 +91,7 @@ src_uri e =
 
 showEBuild :: TC.UTCTime -> EBuild -> String
 showEBuild now ebuild =
-  ss ("# Copyright 1999-" ++ this_year ++ " Gentoo Foundation"). nl.
+  ss ("# Copyright 1999-" ++ this_year ++ " Gentoo Authors"). nl.
   ss "# Distributed under the terms of the GNU General Public License v2". nl.
   nl.
   ss "EAPI=6". nl.


### PR DESCRIPTION
I'm not entirely across the change behind [Gentoo bug 666330](https://bugs.gentoo.org/666330), but I assume that it is worth updating HackPort to generate "Gentoo Authors" by default instead of "Gentoo Foundation", despite repoman automatically updating this before committing.