### PR TITLE
Portage/GHCCore.hs: add libraries bundled with ghc-8.6.1

### DIFF
--- a/Portage/GHCCore.hs
+++ b/Portage/GHCCore.hs
@@ -31,7 +31,7 @@ import Debug.Trace
 -- It means that first ghc in this list is a minmum default.
 ghcs :: [(DC.CompilerInfo, InstalledPackageIndex)]
 ghcs = modern_ghcs
-    where modern_ghcs  = [ghc741, ghc742, ghc761, ghc762, ghc782, ghc7101, ghc7102, ghc801, ghc802, ghc821, ghc843]
+    where modern_ghcs  = [ghc741, ghc742, ghc761, ghc762, ghc782, ghc7101, ghc7102, ghc801, ghc802, ghc821, ghc843, ghc861]
 
 cabalFromGHC :: [Int] -> Maybe Cabal.Version
 cabalFromGHC ver = lookup ver table
@@ -46,6 +46,7 @@ cabalFromGHC ver = lookup ver table
           , ([8,0,2],  Cabal.mkVersion [1,24,2,0])
           , ([8,2,1],  Cabal.mkVersion [2,0,0,2])
           , ([8,4,3],  Cabal.mkVersion [2,2,0,1])
+          , ([8,6,1],  Cabal.mkVersion [2,4,0,1])
           ]
 
 platform :: Platform
@@ -115,6 +116,9 @@ ghc :: [Int] -> DC.CompilerInfo
 ghc nrs = DC.unknownCompilerInfo c_id DC.NoAbiTag
     where c_id = CompilerId GHC (mkVersion nrs)
 
+ghc861 :: (DC.CompilerInfo, InstalledPackageIndex)
+ghc861 = (ghc [8,6,1], mkIndex ghc861_pkgs)
+
 ghc843 :: (DC.CompilerInfo, InstalledPackageIndex)
 ghc843 = (ghc [8,4,3], mkIndex ghc843_pkgs)
 
@@ -151,6 +155,40 @@ ghc741 = (ghc [7,4,1], mkIndex ghc741_pkgs)
 -- | Non-upgradeable core packages
 -- Source: http://haskell.org/haskellwiki/Libraries_released_with_GHC
 --         and our binary tarballs (package.conf.d.initial subdir)
+
+
+ghc861_pkgs :: [Cabal.PackageIdentifier]
+ghc861_pkgs =
+  [ p "array" [0,5,2,0]
+  , p "base" [4,12,0,0]
+  , p "binary" [0,8,6,0] -- used by libghc
+  , p "bytestring" [0,10,8,2]
+--  , p "Cabal" [2,4,0,1]  package is upgradeable
+  , p "containers" [0,6,0,1]
+  , p "deepseq" [1,4,4,0] -- used by time
+  , p "directory" [1,3,3,0]
+  , p "filepath" [1,4,2,1]
+  , p "ghc-boot" [8,6,1] 
+  , p "ghc-boot-th" [8,6,1] 
+  , p "ghc-compact" [0,1,0,0]
+  , p "ghc-prim" [0,5,3,0]
+  , p "ghci" [8,6,1]
+--  , p "haskeline" [0,7,4,3]  package is upgradeable
+  , p "hpc" [0,6,0,3] -- used by libghc
+  , p "integer-gmp" [1,0,2,0]
+  --  , p "mtl" [2,2,2]  package is upgradeable(?)
+  --  , p "parsec" [3,1,13,0]  package is upgradeable(?)
+  , p "pretty" [1,1,3,6]
+  , p "process" [1,6,3,0]
+  --  , p "stm" [2,5,0,0]  package is upgradeable(?)
+  , p "template-haskell" [2,14,0,0] -- used by libghc
+  -- , p "terminfo" [0,4,1,2]
+  -- , p "text" [1,2,3,1] dependency of Cabal library
+  , p "time" [1,8,0,2] -- used by unix, directory, hpc, ghc. unsafe to upgrade
+  , p "transformers" [0,5,5,0] -- used by libghc
+  , p "unix" [2,7,2,2]
+--  , p "xhtml" [3000,2,2,1]
+  ]
 
 ghc843_pkgs :: [Cabal.PackageIdentifier]
 ghc843_pkgs =


### PR DESCRIPTION
The changes build successfully, tested using `cabal build` locally.

The versions of the bundled libraries were determined from both the ghc tarball's `libraries/` directory, and the [GHC 8.6.1 Release Notes](https://downloads.haskell.org/~ghc/8.6.1/docs/html/users_guide/8.6.1-notes.html#included-libraries).

Signed-off-by: Jack Todaro <jackmtodaro@gmail.com>