### PR TITLE
Metadata: automatically generate flags for metadata.xml

### DIFF
--- a/Portage/Metadata.hs
+++ b/Portage/Metadata.hs
@@ -25,9 +25,13 @@ parseMetadata :: Element -> Maybe Metadata
 parseMetadata xml =
   return Metadata { metadata_emails = map strContent (findElements (unqual "email") xml) }
 
+formatFlags :: (String, String) -> String
+formatFlags (name, description) = "\t\t<flag name=\"" ++ name ++
+                                  "\">" ++ description ++ "</flag>"
+
 -- don't use Text.XML.Light as we like our own pretty printer
-makeDefaultMetadata :: String -> String
-makeDefaultMetadata long_description =
+makeDefaultMetadata :: String -> [(String, String)] -> String
+makeDefaultMetadata long_description flags =
     unlines [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
             , "<!DOCTYPE pkgmetadata SYSTEM \"http://www.gentoo.org/dtd/metadata.dtd\">"
             , "<pkgmetadata>"
@@ -35,6 +39,10 @@ makeDefaultMetadata long_description =
             , "\t\t<email>haskell@gentoo.org</email>"
             , "\t\t<name>Gentoo Haskell</name>"
             , "\t</maintainer>"
+            , if (formatFlags <$> flags) == [""]
+              then "\t<use>\n\t</use>"
+              else "\t<use>\n" ++ (unlines $ formatFlags <$> flags) ++
+                   "\t</use>"
             , (init {- strip trailing newline-}
               . unlines
               . map (\l -> if l `elem` ["<longdescription>", "</longdescription>"]


### PR DESCRIPTION
I'm sure more could be done, but I'd like to open this PR for review and suggestions.

This patch changes the type signature and behaviour of `makeDefaultMetadata`
and `mergeEbuild` to accomodate the automatic generation of Cabal flags and
their descriptions in the metadata.xml.

The changes have been tested on two packages: one which has USE flags
(app-text/pandoc), and one which does not (dev-haskell/control-monad-free).
In both circumstances, the generated metadata.xml is correctly formatted.

Where the existing and new metadata.xml differ, the current behaviour of
HackPort remains the same, ie, the current metadata.xml will not be
overwritten.

In the case of a package with no USE flags, currently this patch still writes
the `<use>` and `</use>` tags, but leaves its contents empty.

Bug: https://github.com/gentoo-haskell/hackport/issues/35
Signed-off-by: Jack Todaro <jackmtodaro@gmail.com>