### PR TITLE
hackport.cabal: add dependency bounds, other-modules

### DIFF
--- a/hackport.cabal
+++ b/hackport.cabal
@@ -1,5 +1,5 @@
 Name:           hackport
-Version:        0.6
+Version:        0.6.0.1
 License:        GPL
 License-file:   LICENSE
 Author:         Henning Günther, Duncan Coutts, Lennart Kolmodin
@@ -19,7 +19,7 @@ Executable    hackport
   ghc-options: -Wall
   ghc-prof-options: -caf-all -auto-all -rtsopts
   Main-Is:    Main.hs
-  Default-Language: Haskell98
+  Default-Language: Haskell2010
   Hs-Source-Dirs:
       .,
       cabal,
@@ -27,40 +27,43 @@ Executable    hackport
       cabal/cabal-install,
       hackage-security/hackage-security/src
   Build-Depends:
-    array,
-    base >= 2.0 && < 5,
-    deepseq >= 1.3,
-    extensible-exceptions,
-    filepath,
-    HTTP >= 4000.0.3,
-    MissingH,
-    network >= 2.6, network-uri >= 2.6,
-    parsec,
-    pretty,
-    old-locale,
-    regex-compat,
-    split,
-    tar >= 0.5,
-    time,
-    zlib,
-    xml >= 1.3.7,
-    -- cabal depends
-    binary,
-    random,
-    stm,
-    unix,
-    -- cabal-install depends
-    async,
-    --  hackage-security depends
-    base16-bytestring,
-    base64-bytestring,
-    cryptohash,
-    ed25519,
-    ghc-prim,
-    hashable,
-    mtl,
-    template-haskell,
-    transformers
+    array                 >= 0.5.0.0 && < 0.6,
+    async                 >= 2.0.1.4 && < 2.3,
+    base                  >= 4.7.0.1 && < 5,
+    base16-bytestring     >= 0.1.1.6 && < 0.2,
+    base64-bytestring     >= 1.0.0.1 && < 1.1,
+    binary                >= 0.7.1 && < 0.9,
+    bytestring            >= 0.10.4.0 && < 0.11,
+    containers            >= 0.5.5.1 && < 0.7,
+    cryptohash            >= 0.11.1 && < 0.12,
+    deepseq               >= 1.3.0.2 && < 1.5,
+    directory             >= 1.2.1.0 && < 1.4,
+    ed25519               >= 0.0.5.0 && < 0.1,
+    extensible-exceptions >= 0.1.1.4 && < 0.2,
+    filepath              >= 1.3.0.2 && < 1.5,
+    ghc-prim              >= 0.3.1.0 && < 0.6,
+    hashable              >= 1.2.1.0 && < 1.3,
+    HTTP                  >= 4000.2.8 && < 4000.4,
+    MissingH              >= 1.3.0.1 && < 1.5,
+    mtl                   >= 2.1.3.1 && < 2.3,
+    network               >= 2.6.2.1 && < 2.7,
+    network-uri           >= 2.6.0.3 && < 2.7,
+    old-locale            >= 1.0.0 && < 1.1,
+    old-time              >= 1.1.0 && < 1.2,
+    parsec                >= 3.1.5 && < 3.2,
+    pretty                >= 1.1.1.1 && < 1.2,
+    process               >= 1.2.0.0 && < 1.7,
+    random                >= 1.0.1.1 && < 1.2,
+    regex-compat          >= 0.95.1 && < 0.96,
+    split                 >= 0.2.2 && < 0.3,
+    stm                   >= 2.4.2 && < 2.6,
+    tar                   >= 0.5.0.3 && < 0.6,
+    template-haskell      >= 2.9.0.0 && < 2.15,
+    time                  >= 1.4.1 && < 1.9,
+    transformers          >= 0.3.0.0 && < 0.6,
+    unix                  >= 2.7.0.1 && < 2.8,
+    xml                   >= 1.3.13 && < 1.4,
+    zlib                  >= 0.5.4.2 && < 0.7
 
   default-extensions:
     -- hackage-security
@@ -98,54 +101,322 @@ Executable    hackport
     RecordWildCards,
     TypeOperators
 
-  Build-Depends:
-    base >= 3 && < 5,
-    directory,
-    containers,
-    process,
-    old-time,
-    bytestring
-
   other-modules:
+    -- Hackage Security
+    Hackage.Security.Client
+    Hackage.Security.Client.Formats
+    Hackage.Security.Client.Repository
+    Hackage.Security.Client.Repository.Cache
+    Hackage.Security.Client.Repository.HttpLib
+    Hackage.Security.Client.Repository.Local
+    Hackage.Security.Client.Repository.Remote
+    Hackage.Security.Client.Verify
+    Hackage.Security.JSON
+    Hackage.Security.Key
+    Hackage.Security.Key.Env
+    Hackage.Security.TUF
+    Hackage.Security.TUF.Common
+    Hackage.Security.TUF.FileInfo
+    Hackage.Security.TUF.FileMap
+    Hackage.Security.TUF.Header
+    Hackage.Security.TUF.Layout.Cache
+    Hackage.Security.TUF.Layout.Index
+    Hackage.Security.TUF.Layout.Repo
+    Hackage.Security.TUF.Mirrors
+    Hackage.Security.TUF.Paths
+    Hackage.Security.TUF.Patterns
+    Hackage.Security.TUF.Root
+    Hackage.Security.TUF.Signed
+    Hackage.Security.TUF.Snapshot
+    Hackage.Security.TUF.Targets
+    Hackage.Security.TUF.Timestamp
+    Hackage.Security.Trusted
+    Hackage.Security.Trusted.TCB
+    Hackage.Security.Util.Base64
+    Hackage.Security.Util.Checked
+    Hackage.Security.Util.Exit
+    Hackage.Security.Util.FileLock
+    Hackage.Security.Util.IO
+    Hackage.Security.Util.JSON
+    Hackage.Security.Util.Lens
+    Hackage.Security.Util.Path
+    Hackage.Security.Util.Pretty
+    Hackage.Security.Util.Some
+    Hackage.Security.Util.Stack
+    Hackage.Security.Util.TypedEmbedded
+    -- cabal
+    Distribution.Backpack
+    Distribution.Backpack.ComponentsGraph
+    Distribution.Backpack.Configure
+    Distribution.Backpack.ConfiguredComponent
+    Distribution.Backpack.DescribeUnitId
+    Distribution.Backpack.FullUnitId
+    Distribution.Backpack.Id
+    Distribution.Backpack.LinkedComponent
+    Distribution.Backpack.MixLink
+    Distribution.Backpack.ModSubst
+    Distribution.Backpack.ModuleScope
+    Distribution.Backpack.ModuleShape
+    Distribution.Backpack.PreExistingComponent
+    Distribution.Backpack.PreModuleShape
+    Distribution.Backpack.ReadyComponent
+    Distribution.Backpack.UnifyM
+    Distribution.Client.BuildReports.Types
+    Distribution.Client.Compat.Prelude
+    Distribution.Client.Compat.Semaphore
+    Distribution.Client.Config
+    Distribution.Client.Dependency.Types
+    Distribution.Client.FetchUtils
+    Distribution.Client.GZipUtils
+    Distribution.Client.GlobalFlags
+    Distribution.Client.HttpUtils
+    Distribution.Client.IndexUtils
+    Distribution.Client.IndexUtils.Timestamp
+    Distribution.Client.Init.Types
+    Distribution.Client.JobControl
+    Distribution.Client.ParseUtils
+    Distribution.Client.Security.DNS
+    Distribution.Client.Security.HTTP
+    Distribution.Client.Setup
+    Distribution.Client.Tar
+    Distribution.Client.Targets
+    Distribution.Client.Types
+    Distribution.Client.Update
+    Distribution.Client.Utils
+    Distribution.Client.World
+    Distribution.Compat.Binary
+    Distribution.Compat.CopyFile
+    Distribution.Compat.CreatePipe
+    Distribution.Compat.DList
+    Distribution.Compat.Environment
+    Distribution.Compat.Exception
+    Distribution.Compat.Graph
+    Distribution.Compat.Internal.TempFile
+    Distribution.Compat.Lens
+    Distribution.Compat.Map.Strict
+    Distribution.Compat.MonadFail
+    Distribution.Compat.Newtype
+    Distribution.Compat.Parsec
+    Distribution.Compat.Prelude
+    Distribution.Compat.Prelude.Internal
+    Distribution.Compat.ReadP
+    Distribution.Compat.Semigroup
+    Distribution.Compat.Stack
+    Distribution.Compat.Time
+    Distribution.Compiler
+    Distribution.FieldGrammar
+    Distribution.FieldGrammar.Class
+    Distribution.FieldGrammar.Parsec
+    Distribution.FieldGrammar.Pretty
+    Distribution.GetOpt
+    Distribution.InstalledPackageInfo
+    Distribution.Lex
+    Distribution.License
+    Distribution.ModuleName
+    Distribution.Package
+    Distribution.PackageDescription
+    Distribution.PackageDescription.Check
+    Distribution.PackageDescription.Configuration
+    Distribution.PackageDescription.FieldGrammar
+    Distribution.PackageDescription.Parse
+    Distribution.PackageDescription.Parsec
+    Distribution.PackageDescription.PrettyPrint
+    Distribution.PackageDescription.Quirks
+    Distribution.PackageDescription.Utils
+    Distribution.ParseUtils
+    Distribution.Parsec.Class
+    Distribution.Parsec.Common
+    Distribution.Parsec.ConfVar
+    Distribution.Parsec.Field
+    Distribution.Parsec.Lexer
+    Distribution.Parsec.LexerMonad
+    Distribution.Parsec.Newtypes
+    Distribution.Parsec.ParseResult
+    Distribution.Parsec.Parser
+    Distribution.Pretty
+    Distribution.ReadE
+    Distribution.Simple.Build.PathsModule
+    Distribution.Simple.BuildPaths
+    Distribution.Simple.BuildTarget
+    Distribution.Simple.BuildToolDepends
+    Distribution.Simple.CCompiler
+    Distribution.Simple.Command
+    Distribution.Simple.Compiler
+    Distribution.Simple.Configure
+    Distribution.Simple.GHC
+    Distribution.Simple.GHC.IPI642
+    Distribution.Simple.GHC.IPIConvert
+    Distribution.Simple.GHC.ImplInfo
+    Distribution.Simple.GHC.Internal
+    Distribution.Simple.GHCJS
+    Distribution.Simple.HaskellSuite
+    Distribution.Simple.Hpc
+    Distribution.Simple.InstallDirs
+    Distribution.Simple.JHC
+    Distribution.Simple.LHC
+    Distribution.Simple.LocalBuildInfo
+    Distribution.Simple.PackageIndex
+    Distribution.Simple.PreProcess
+    Distribution.Simple.PreProcess.Unlit
+    Distribution.Simple.Program
+    Distribution.Simple.Program.Ar
+    Distribution.Simple.Program.Builtin
+    Distribution.Simple.Program.Db
+    Distribution.Simple.Program.Find
+    Distribution.Simple.Program.GHC
+    Distribution.Simple.Program.HcPkg
+    Distribution.Simple.Program.Hpc
+    Distribution.Simple.Program.Internal
+    Distribution.Simple.Program.Ld
+    Distribution.Simple.Program.ResponseFile
+    Distribution.Simple.Program.Run
+    Distribution.Simple.Program.Strip
+    Distribution.Simple.Program.Types
+    Distribution.Simple.Setup
+    Distribution.Simple.Test.LibV09
+    Distribution.Simple.Test.Log
+    Distribution.Simple.UHC
+    Distribution.Simple.Utils
+    Distribution.Solver.Compat.Prelude
+    Distribution.Solver.Types.ComponentDeps
+    Distribution.Solver.Types.ConstraintSource
+    Distribution.Solver.Types.LabeledPackageConstraint
+    Distribution.Solver.Types.OptionalStanza
+    Distribution.Solver.Types.PackageConstraint
+    Distribution.Solver.Types.PackageFixedDeps
+    Distribution.Solver.Types.PackageIndex
+    Distribution.Solver.Types.PackagePath
+    Distribution.Solver.Types.Settings
+    Distribution.Solver.Types.SourcePackage
+    Distribution.System
+    Distribution.TestSuite
+    Distribution.Text
+    Distribution.Types.AbiHash
+    Distribution.Types.AnnotatedId
+    Distribution.Types.Benchmark
+    Distribution.Types.Benchmark.Lens
+    Distribution.Types.BenchmarkInterface
+    Distribution.Types.BenchmarkType
+    Distribution.Types.BuildInfo
+    Distribution.Types.BuildInfo.Lens
+    Distribution.Types.BuildType
+    Distribution.Types.Component
+    Distribution.Types.ComponentId
+    Distribution.Types.ComponentInclude
+    Distribution.Types.ComponentLocalBuildInfo
+    Distribution.Types.ComponentName
+    Distribution.Types.ComponentRequestedSpec
+    Distribution.Types.CondTree
+    Distribution.Types.Condition
+    Distribution.Types.Dependency
+    Distribution.Types.DependencyMap
+    Distribution.Types.ExeDependency
+    Distribution.Types.Executable
+    Distribution.Types.Executable.Lens
+    Distribution.Types.ExecutableScope
+    Distribution.Types.ForeignLib
+    Distribution.Types.ForeignLib.Lens
+    Distribution.Types.ForeignLibOption
+    Distribution.Types.ForeignLibType
+    Distribution.Types.GenericPackageDescription
+    Distribution.Types.GenericPackageDescription.Lens
+    Distribution.Types.HookedBuildInfo
+    Distribution.Types.IncludeRenaming
+    Distribution.Types.LegacyExeDependency
+    Distribution.Types.Lens
+    Distribution.Types.Library
+    Distribution.Types.Library.Lens
+    Distribution.Types.LocalBuildInfo
+    Distribution.Types.Mixin
+    Distribution.Types.Module
+    Distribution.Types.ModuleReexport
+    Distribution.Types.ModuleRenaming
+    Distribution.Types.MungedPackageId
+    Distribution.Types.MungedPackageName
+    Distribution.Types.PackageDescription
+    Distribution.Types.PackageDescription.Lens
+    Distribution.Types.PackageId
+    Distribution.Types.PackageId.Lens
+    Distribution.Types.PackageName
+    Distribution.Types.PkgconfigDependency
+    Distribution.Types.PkgconfigName
+    Distribution.Types.SetupBuildInfo
+    Distribution.Types.SetupBuildInfo.Lens
+    Distribution.Types.SourceRepo
+    Distribution.Types.SourceRepo.Lens
+    Distribution.Types.TargetInfo
+    Distribution.Types.TestSuite
+    Distribution.Types.TestSuite.Lens
+    Distribution.Types.TestSuiteInterface
+    Distribution.Types.TestType
+    Distribution.Types.UnitId
+    Distribution.Types.UnqualComponentName
+    Distribution.Types.Version
+    Distribution.Types.VersionInterval
+    Distribution.Types.VersionRange
+    Distribution.Utils.Base62
+    Distribution.Utils.Generic
+    Distribution.Utils.IOData
+    Distribution.Utils.LogProgress
+    Distribution.Utils.MapAccum
+    Distribution.Utils.NubList
+    Distribution.Utils.Progress
+    Distribution.Utils.ShortText
+    Distribution.Utils.String
+    Distribution.Utils.UnionFind
+    Distribution.Verbosity
+    Distribution.Version
+    -- Hackport and miscellaneous            
     AnsiColor
     Cabal2Ebuild
     Error
+    HackPort.GlobalFlags
+    Language.Haskell.Extension
+    Merge
+    Merge.Dependencies
     Overlays
+    Paths_cabal_install
     Paths_hackport
-    Portage.Version
+    Portage.Cabal
     Portage.Dependency
+    Portage.Dependency.Builder
+    Portage.Dependency.Normalize
+    Portage.Dependency.Print
+    Portage.Dependency.Types
     Portage.EBuild
     Portage.EBuild.CabalFeature
     Portage.EBuild.Render
+    Portage.EMeta
     Portage.GHCCore
-    Portage.PackageId
-    Portage.Overlay
-    Portage.Resolve
     Portage.Host
+    Portage.Metadata
+    Portage.Overlay
+    Portage.PackageId
+    Portage.Resolve
     Portage.Tables
-    Merge.Dependencies
+    Portage.Use
+    Portage.Version
+    Prelude
     Status
-    Merge
+    Text.JSON.Canonical
     Util
-    -- hsc files
-    Hackage.Security.Util.FileLock
 
 Test-Suite test-resolve-category
   ghc-options: -Wall
   Type:                 exitcode-stdio-1.0
-  Default-Language:     Haskell98
+  Default-Language:     Haskell2010
   Main-Is:              tests/resolveCat.hs
   Hs-Source-Dirs:       ., cabal, cabal/Cabal, cabal/cabal-install, tests
   Build-Depends:        array,
-                        base >= 3 && < 5,
+                        base,
                         binary,
-                        deepseq >= 1.3,
+                        deepseq,
                         bytestring,
                         containers,
                         directory,
                         extensible-exceptions,
                         filepath,
-                        HUnit,
+                        HUnit >= 1.2.5.2 && < 1.7,
                         parsec,
                         pretty,
                         process,
@@ -157,13 +428,13 @@ Test-Suite test-resolve-category
 Test-Suite test-print-deps
   ghc-options: -Wall
   Type:                 exitcode-stdio-1.0
-  Default-Language:     Haskell98
+  Default-Language:     Haskell2010
   Main-Is:              tests/print_deps.hs
   Hs-Source-Dirs:       ., cabal, cabal/Cabal, cabal/cabal-install, tests
   Build-Depends:        array,
-                        base >= 3 && < 5,
+                        base,
                         binary,
-                        deepseq >= 1.3,
+                        deepseq,
                         bytestring,
                         containers,
                         directory,
@@ -180,13 +451,13 @@ Test-Suite test-print-deps
 Test-Suite test-normalize-deps
   ghc-options: -Wall
   Type:                 exitcode-stdio-1.0
-  Default-Language:     Haskell98
+  Default-Language:     Haskell2010
   Main-Is:              tests/normalize_deps.hs
   Hs-Source-Dirs:       ., cabal, cabal/Cabal, cabal/cabal-install, tests
   Build-Depends:        array,
-                        base >= 3 && < 5,
+                        base,
                         binary,
-                        deepseq >= 1.3,
+                        deepseq,
                         bytestring,
                         containers,
                         directory,


### PR DESCRIPTION
The proposed changes are:
* Add dependency bounds as per a request by the Hackage Trustees (**note:** I have set the lower bounds to either those packaged with `ghc-7.8.3` and its `haskell-platform` release, or the highest stable version available in `::gentoo`)
* Update default language to `Haskell2010`
* Add `hackage-security` and `cabal` modules to `other-modules` to silence warnings about missing modules
* Bump version number provisionally to 0.6.0.1