### PR TITLE
Implement basic diff functionality

### DIFF
--- a/Portage/PackageId.hs
+++ b/Portage/PackageId.hs
@@ -40,7 +40,7 @@ import Prelude hiding ((<>))
 newtype Category = Category { unCategory :: String }
   deriving (Eq, Ord, Show, Read)
 
-data PackageName = PackageName Category Cabal.PackageName
+data PackageName = PackageName { category :: Category, cabalPkgName :: Cabal.PackageName }
   deriving (Eq, Ord, Show, Read)
 
 data PackageId = PackageId { packageId :: PackageName, pkgVersion :: Portage.Version }


### PR DESCRIPTION
Opening for review and suggestions.

**Overview**
This teaches hackport to generate and display a diff between a newly-merged
version of a package and its most immediate previous version, if available.
This is not currently switchable. If there is no previous version available
such as when merging a new package, hackport will not call diff.

**Benefits**
The main benefit of this functionality is to allow the ebuild author to more
easily detect unintended changes between version bumps. A small diff is
likely to suggest no major changes, whereas a large diff should signal to
the ebuild author that further investigation may be necessary.

**Room for improvement**

- More use of parsers could be used to clean up the `filePathToPackageId` function
- Improve error handling and propagation by using the `Maybe` type constructor
  rather than propagating an infallible fallback value (see `Portage.PackageId.filePathToPackageId`).
  To clarify, here is the process for `filePathToPackageId` handling an invalid version
  number from a given `FilePath` (which should only be an ebuild):

1. Detect that the parsed version number is invalid
2. Return the existing PackageId of the new package version
3. Filter out all versions equal to or greater than the version of the new package
    in `Merge.getPreviousPackageId`. This filters out the PackageId of the new package version
    propagated by `Portage.PackageId.filePathToPackageId`. This filtration is already
    necessary to determine which `FilePath`s are valid ebuilds
4. Use the next valid ebuild to diff against, propagating `Just x`, or propagate `Nothing`.

  **EDIT:** the following no longer applies as of c790d59 ~~Additionally, this may remove the need to hardcode the filtering out of irrelevant files such as `metadata.xml`, thereby improving the general reliability of the functionality.~~

**Testing**
I've tested this to work on:

- xmonad (test if -9999 ebuild or unusual category break functionality)
- pinch (test if new packages break functionality)
- cabal (test if masked, higher versions than that being merged break functionality)
- pandoc (general testing)
- yi-rope (test version number comparison, ie that 0.7 < 0.11, unlike with
  integer comparisons)

For example:

*   foo-a.b.ebuild has been patched using cabal_chdep. Hackport has no way
    of knowing if version foo-a.b+1.ebuild also requires this. The ebuild
    is likely to pass repoman, but it is unlikely to emerge as intended.

*   Package bar has its dependency on cabal removed to avoid circular
    dependencies (this is particularly relevant to packages close to GHC).
    Hackport has no way of knowing if this is still necessary. The new version
    of the ebuild may pass repoman, but it may cause circular dependencies
    for users.