### PR TITLE
Merge.hs: encode default_meta with UTF-8

### DIFF
--- a/Merge.hs
+++ b/Merge.hs
@@ -6,6 +6,7 @@ module Merge
 import Control.Monad
 import Control.Exception
 import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.ByteString.Builder as BL (stringUtf8, toLazyByteString)
 import Data.Function (on)
 import Data.Maybe
 import qualified Data.List as L
@@ -466,7 +467,9 @@ mergeEbuild verbosity existing_meta pkgdir ebuild flags = do
       epath = edir </> elocal
       emeta = "metadata.xml"
       mpath = edir </> emeta
-      default_meta = BL.pack $ Portage.makeDefaultMetadata (E.long_desc ebuild) (metaFlags flags)
+      default_meta = BL.toLazyByteString . BL.stringUtf8
+                     $ Portage.makeDefaultMetadata (E.long_desc ebuild)
+                     $ metaFlags flags
   createDirectoryIfMissing True edir
   now <- TC.getCurrentTime
 


### PR DESCRIPTION
Instead of packing `default_meta` directly into a `ByteString` (or the earlier discussed solution of using `Text`), this patch:
1. encodes to UTF-8 using `stringUtf8` from `Data.ByteString.Builder`; and
2. converts the resultant `Builder` into a lazy `ByteString`.

Everything else remains the same.

I decided on this method over using `Text` on the presumption that it may be more efficient. If you're happy with this implementation, I'll go ahead and push it.