### PR TITLE
Portage/Host.hs: improved portage guess

### DIFF
--- a/Error.hs
+++ b/Error.hs
@@ -51,9 +51,9 @@ hackPortShowError err = case err of
     ExtractionFailed tarball file code -> "Extracting '"++file++"' from '"++tarball++"' failed with '"++show code++"'"
     CabalParseFailed file reason -> "Error while parsing cabal file '"++file++"': "++reason
     BashNotFound -> "The 'bash' executable was not found. It is required to figure out your portage-overlay. If you don't want to install bash, use '-p path-to-overlay'"
-    BashError str -> "Error while guessing your portage-overlay. Either set PORTDIR_OVERLAY in /etc/make.conf or use '-p path-to-overlay'.\nThe error was: \""++str++"\""
+    BashError str -> "Error while guessing your repository's location. Either set a repository 'haskell' in '/etc/portage/repos.conf' or use '-p path-to-overlay'.\nThe error was: \""++str++"\""
     MultipleOverlays overlays -> "You have the following overlays available: '"++unwords overlays++"'. Please choose one by using 'hackport -p path-to-overlay' <command>"
-    NoOverlay -> "You don't have PORTDIR_OVERLAY set in '/etc/make.conf'. Please set it or use '-p path-to-overlay'"
+    NoOverlay -> "Unable to find a repository 'haskell'. Consider defining it in '/etc/portage/repos.conf' and verify '~/.hackport/repositories' (in overlay_list) or use '-p path-to-overlay'"
     UnknownVerbosityLevel str -> "The verbosity level '"++str++"' is invalid. Please use debug,normal or silent"
     InvalidServer srv -> "Invalid server address, could not parse: " ++ srv
     --WrongCacheVersion -> "The version of the cache is too old. Please update the cache using 'hackport update'"


### PR DESCRIPTION
Found a few kinks while getting started with hackport (as of 0.6 release).

Problem: The approach to grab `portage_dir` and `overlay_list` results in
`Nothing`, as they are no longer reported by `emerge --info`. There are error
messages that advise to set PORTDIR_OVERLAY in '/etc/make.conf'. Wrong file
location and obsolete variable. The message in (aptly named)
`showAnnoyingWarning` reflects missing information (my portage is in
'/var/portage' but it prints '/usr/portage'). This applies to `getInfo` using
emerge (no idea for paludis but the adjustments should not affect it).

Solution: Query `portageq` which is bundled with sys-apps/portage (instead of
parse-and-pray). Note that it does not have an advisable direct equivalent of
PORTDIR_OVERLAY, but provides the path to specific repositories. Assumption
made here: the repository of interest goes by the name "haskell". Updated two
related error messages in "Error.hs". Eventually one might remove altogether
the overlay_list and replace it with a simple and direct repo_dir.

Tested with a patched ebuild of hackport-0.6.
ghc 8.6.5, portage 2.3.76

Signed-off-by: Philippe Baril Lecavalier <pbl.ltx@gmail.com>