### PR TITLE
Port away from Distribution.Text and Distribution.Compat.ReadP

### DIFF
--- a/Cabal2Ebuild.hs
+++ b/Cabal2Ebuild.hs
@@ -26,7 +26,7 @@ import qualified Distribution.PackageDescription as Cabal
 import qualified Distribution.Package as Cabal  (PackageIdentifier(..)
                                                 , Dependency(..))
 import qualified Distribution.Version as Cabal  (VersionRange, foldVersionRange')
-import Distribution.Text (display)
+import Distribution.Pretty (prettyShow)
 
 import Data.Char          (isUpper)
 import Data.Maybe
@@ -44,9 +44,9 @@ import Portage.Version
 cabal2ebuild :: Portage.Category -> Cabal.PackageDescription -> Portage.EBuild
 cabal2ebuild cat pkg = Portage.ebuildTemplate {
     E.name        = Portage.cabal_pn_to_PN cabal_pn,
-    E.category    = display cat,
+    E.category    = prettyShow cat,
     E.hackage_name= cabalPkgName,
-    E.version     = display (Cabal.pkgVersion (Cabal.package pkg)),
+    E.version     = prettyShow (Cabal.pkgVersion (Cabal.package pkg)),
     E.description = if null (Cabal.synopsis pkg) then Cabal.description pkg
                                                else Cabal.synopsis pkg,
     E.long_desc       = if null (Cabal.description pkg) then Cabal.synopsis pkg
@@ -69,7 +69,7 @@ cabal2ebuild cat pkg = Portage.ebuildTemplate {
                                    else [])
   } where
         cabal_pn = Cabal.pkgName $ Cabal.package pkg
-        cabalPkgName = display cabal_pn
+        cabalPkgName = prettyShow cabal_pn
         hasLibs = isJust (Cabal.library pkg)
         hasTests = (not . null) (Cabal.testSuites pkg)
         thisHomepage = if (null $ Cabal.homepage pkg)

--- a/Main.hs
+++ b/Main.hs
@@ -22,7 +22,10 @@ import Distribution.Simple.Utils ( dieNoVerbosity, cabalVersion, warn )
 import qualified Distribution.PackageDescription.Parsec as Cabal
 import qualified Distribution.Package as Cabal
 import Distribution.Verbosity (Verbosity, normal)
-import Distribution.Text (display, simpleParse)
+
+import Data.Version (showVersion)
+import Distribution.Pretty (prettyShow)
+import Distribution.Parsec.Class (simpleParsec)
 
 import qualified Distribution.Client.Setup as CabalInstall
 import qualified Distribution.Client.Types as CabalInstall
@@ -122,7 +125,7 @@ listAction flags extraArgs globalFlags = do
   pretty (isInOverlay, pkgId) =
       let dec | isInOverlay = " * "
               | otherwise   = "   "
-      in dec ++ display pkgId
+      in dec ++ prettyShow pkgId
 
 
 -----------------------------------------------------------------------
@@ -167,7 +170,7 @@ makeEbuildAction flags args globalFlags = do
   (catstr,cabals) <- case args of
                       (category:cabal1:cabaln) -> return (category, cabal1:cabaln)
                       _ -> throwEx (ArgumentError "make-ebuild needs at least two arguments. <category> <cabal-1> <cabal-n>")
-  cat <- case simpleParse catstr of
+  cat <- case simpleParsec catstr of
             Just c -> return c
             Nothing -> throwEx (ArgumentError ("could not parse category: " ++ catstr))
   let verbosity = fromFlag (makeEbuildVerbosity flags)
@@ -475,13 +478,13 @@ mainWorker args =
     printErrors errs = do
       putStr (concat (intersperse "\n" errs))
       exitFailure
-    printNumericVersion = putStrLn $ display Paths_hackport.version
+    printNumericVersion = putStrLn $ showVersion Paths_hackport.version
     printVersion        = putStrLn $ "hackport version "
-                                  ++ display Paths_hackport.version
+                                  ++ showVersion Paths_hackport.version
                                   ++ "\nusing cabal-install "
-                                  ++ display Paths_cabal_install.version
+                                  ++ showVersion Paths_cabal_install.version
                                   ++ " and the Cabal library version "
-                                  ++ display cabalVersion
+                                  ++ prettyShow cabalVersion
     errorHandler :: HackPortError -> IO ()
     errorHandler e = do
       putStrLn (hackPortShowError e)

--- a/Merge.hs
+++ b/Merge.hs
@@ -80,10 +80,13 @@ readPackageString args = do
       [pkg] -> return pkg
       _ -> Left (ArgumentError ("Too many arguments: " ++ unwords args))
   case Portage.parseFriendlyPackage packageString of
-    Just v@(_,_,Nothing) -> return v
+    Right v@(_,_,Nothing) -> return v
     -- we only allow versions we can convert into cabal versions
-    Just v@(_,_,Just (Portage.Version _ Nothing [] 0)) -> return v
-    _ -> Left (ArgumentError ("Could not parse [category/]package[-version]: " ++ packageString))
+    Right v@(_,_,Just (Portage.Version _ Nothing [] 0)) -> return v
+    Left e -> Left $ ArgumentError $ "Could not parse [category/]package[-version]: "
+              ++ packageString ++ "\nParsec error: " ++ e
+    _ -> Left $ ArgumentError $ "Could not parse [category/]package[-version]: "
+         ++ packageString
 
 
 

--- a/Merge.hs
+++ b/Merge.hs
@@ -21,7 +21,7 @@ import qualified Distribution.PackageDescription.PrettyPrint as Cabal (showPacka
 import qualified Distribution.Solver.Types.SourcePackage as CabalInstall
 import qualified Distribution.Solver.Types.PackageIndex as CabalInstall
 
-import Distribution.Text (display)
+import Distribution.Pretty (prettyShow)
 import Distribution.Verbosity
 import Distribution.Simple.Utils
 
@@ -129,7 +129,7 @@ merge verbosity repoContext args overlayPath users_cabal_flags = do
                   notice verbosity $ "Ambiguous names: " ++ L.intercalate ", " names
                   forM_ pkgs $ \ps ->
                       do let p_name = (cabal_pkg_to_pn . L.head) ps
-                         notice verbosity $ p_name ++ ": " ++ (L.intercalate ", " $ map (display . Cabal.pkgVersion . CabalInstall.packageInfoId) ps)
+                         notice verbosity $ p_name ++ ": " ++ (L.intercalate ", " $ map (prettyShow . Cabal.pkgVersion . CabalInstall.packageInfoId) ps)
                   return $ concat pkgs
 
   -- select a single package taking into account the user specified version
@@ -138,7 +138,7 @@ merge verbosity repoContext args overlayPath users_cabal_flags = do
       Nothing -> do
         putStrLn "No such version for that package, available versions:"
         forM_ availablePkgs $ \ avail ->
-          putStrLn (display . CabalInstall.packageInfoId $ avail)
+          putStrLn (prettyShow . CabalInstall.packageInfoId $ avail)
         throwEx (ArgumentError "no such version for that package")
       Just avail -> return avail
 
@@ -147,7 +147,7 @@ merge verbosity repoContext args overlayPath users_cabal_flags = do
   forM_ availablePkgs $ \ avail -> do
     let match_text | CabalInstall.packageInfoId avail == CabalInstall.packageInfoId selectedPkg = "* "
                    | otherwise = "- "
-    info verbosity $ match_text ++ (display . CabalInstall.packageInfoId $ avail)
+    info verbosity $ match_text ++ (prettyShow . CabalInstall.packageInfoId $ avail)
 
   let cabal_pkgId = CabalInstall.packageInfoId selectedPkg
       norm_pkgName = Cabal.packageName (Portage.normalizeCabalPackageId cabal_pkgId)
@@ -253,8 +253,8 @@ mergeGenericPackageDescription verbosity overlayPath cat pkgGenericDesc fetch us
   debug verbosity "searching for minimal suitable ghc version"
   (compiler_info, ghc_packages, pkgDesc0, _flags, pix) <- case GHCCore.minimumGHCVersionToBuildPackage pkgGenericDesc (Cabal.mkFlagAssignment user_specified_fas) of
               Just v  -> return v
-              Nothing -> let pn = display merged_cabal_pkg_name
-                             cn = display cat
+              Nothing -> let pn = prettyShow merged_cabal_pkg_name
+                             cn = prettyShow cat
                          in error $ unlines [ "mergeGenericPackageDescription: failed to find suitable GHC for " ++ pn
                                             , "  You can try to merge the package manually:"
                                             , "  $ cabal unpack " ++ pn
@@ -384,11 +384,11 @@ mergeGenericPackageDescription verbosity overlayPath cat pkgGenericDesc fetch us
       cabal_to_emerge_dep cabal_pkg = Merge.resolveDependencies overlay cabal_pkg compiler_info ghc_packages merged_cabal_pkg_name
 
   debug verbosity $ "buildDepends pkgDesc0 raw: " ++ Cabal.showPackageDescription pkgDesc0
-  debug verbosity $ "buildDepends pkgDesc0: " ++ show (map display (Merge.exeAndLibDeps pkgDesc0))
-  debug verbosity $ "buildDepends pkgDesc:  " ++ show (map display (Merge.buildDepends pkgDesc))
+  debug verbosity $ "buildDepends pkgDesc0: " ++ show (map prettyShow (Merge.exeAndLibDeps pkgDesc0))
+  debug verbosity $ "buildDepends pkgDesc:  " ++ show (map prettyShow (Merge.buildDepends pkgDesc))
 
-  notice verbosity $ "Accepted depends: " ++ show (map display accepted_deps)
-  notice verbosity $ "Skipped  depends: " ++ show (map display skipped_deps)
+  notice verbosity $ "Accepted depends: " ++ show (map prettyShow accepted_deps)
+  notice verbosity $ "Skipped  depends: " ++ show (map prettyShow skipped_deps)
   notice verbosity $ "Dead flags: " ++ show (map pp_fa irresolvable_flag_assignments)
   notice verbosity $ "Dropped  flags: " ++ show (map (Cabal.unFlagName.fst) common_fa)
   notice verbosity $ "Active flags: " ++ show (map Cabal.unFlagName active_flags)
@@ -442,7 +442,7 @@ mergeGenericPackageDescription verbosity overlayPath cat pkgGenericDesc fetch us
   when fetch $ do
     let cabal_pkgId = Cabal.packageId (Merge.packageDescription pkgDesc)
         norm_pkgName = Cabal.packageName (Portage.normalizeCabalPackageId cabal_pkgId)
-    fetchDigestAndCheck verbosity (overlayPath </> display cat </> display norm_pkgName)
+    fetchDigestAndCheck verbosity (overlayPath </> prettyShow cat </> prettyShow norm_pkgName)
 
 fetchDigestAndCheck :: Verbosity
                     -> FilePath -- ^ directory of ebuild

--- a/Portage/Dependency/Print.hs
+++ b/Portage/Dependency/Print.hs
@@ -11,7 +11,7 @@ import Portage.Use
 
 import Portage.PackageId
 
-import qualified Distribution.Text as DT
+import qualified Distribution.Pretty as DP (Pretty(..))
 import qualified Text.PrettyPrint as Disp
 import Text.PrettyPrint ( vcat, nest, render )
 import Text.PrettyPrint as PP ((<>))
@@ -24,13 +24,13 @@ dispSlot AnyBuildTimeSlot = Disp.text ":="
 dispSlot (GivenSlot slot) = Disp.text (':' : slot)
 
 dispLBound :: PackageName -> LBound -> Disp.Doc
-dispLBound pn (StrictLB    v) = Disp.char '>' PP.<> DT.disp pn <-> DT.disp v
-dispLBound pn (NonstrictLB v) = Disp.text ">=" PP.<> DT.disp pn <-> DT.disp v
+dispLBound pn (StrictLB    v) = Disp.char '>' PP.<> DP.pretty pn <-> DP.pretty v
+dispLBound pn (NonstrictLB v) = Disp.text ">=" PP.<> DP.pretty pn <-> DP.pretty v
 dispLBound _pn ZeroB = error "unhandled 'dispLBound ZeroB'"
 
 dispUBound :: PackageName -> UBound -> Disp.Doc
-dispUBound pn (StrictUB    v) = Disp.char '<' PP.<> DT.disp pn <-> DT.disp v
-dispUBound pn (NonstrictUB v) = Disp.text "<=" PP.<> DT.disp pn <-> DT.disp v
+dispUBound pn (StrictUB    v) = Disp.char '<' PP.<> DP.pretty pn <-> DP.pretty v
+dispUBound pn (NonstrictUB v) = Disp.text "<=" PP.<> DP.pretty pn <-> DP.pretty v
 dispUBound _pn InfinityB = error "unhandled 'dispUBound Infinity'"
 
 dispDAttr :: DAttr -> Disp.Doc
@@ -58,7 +58,7 @@ showDepend :: Dependency -> Disp.Doc
 showDepend (DependAtom (Atom pn range dattr))
     = case range of
         -- any version
-        DRange ZeroB InfinityB -> DT.disp pn       PP.<> dispDAttr dattr
+        DRange ZeroB InfinityB -> DP.pretty pn       PP.<> dispDAttr dattr
         DRange ZeroB ub        -> dispUBound pn ub PP.<> dispDAttr dattr
         DRange lb InfinityB    -> dispLBound pn lb PP.<> dispDAttr dattr
         -- TODO: handle >=foo-0    special case
@@ -66,15 +66,15 @@ showDepend (DependAtom (Atom pn range dattr))
         DRange lb ub          ->    showDepend (DependAtom (Atom pn (DRange lb InfinityB) dattr))
                                  PP.<> Disp.char ' '
                                  PP.<> showDepend (DependAtom (Atom pn (DRange ZeroB ub)    dattr))
-        DExact v              -> Disp.char '~' PP.<> DT.disp pn <-> DT.disp v { versionRevision = 0 } PP.<> dispDAttr dattr
+        DExact v              -> Disp.char '~' PP.<> DP.pretty pn <-> DP.pretty v { versionRevision = 0 } PP.<> dispDAttr dattr
 
 showDepend (DependIfUse u td fd)  = valign $ vcat [td_doc, fd_doc]
     where td_doc
               | is_empty_dependency td = Disp.empty
-              | otherwise =                  DT.disp u PP.<> Disp.char '?' PP.<> sp PP.<> sparens (showDepend td)
+              | otherwise =                  DP.pretty u PP.<> Disp.char '?' PP.<> sp PP.<> sparens (showDepend td)
           fd_doc
               | is_empty_dependency fd = Disp.empty
-              | otherwise = Disp.char '!' PP.<> DT.disp u PP.<> Disp.char '?' PP.<> sp PP.<> sparens (showDepend fd)
+              | otherwise = Disp.char '!' PP.<> DP.pretty u PP.<> Disp.char '?' PP.<> sp PP.<> sparens (showDepend fd)
 showDepend (DependAnyOf deps)   = Disp.text "||" PP.<> sp PP.<> sparens (vcat $ map showDependInAnyOf deps)
 showDepend (DependAllOf deps)   = valign $ vcat $ map showDepend deps
 

--- a/Portage/Overlay.hs
+++ b/Portage/Overlay.hs
@@ -16,7 +16,7 @@ import qualified Portage.Metadata as Portage
 
 import qualified Distribution.Package as Cabal
 
-import Distribution.Text (simpleParse)
+import Distribution.Parsec.Class (simpleParsec)
 import Distribution.Simple.Utils ( comparing, equating )
 
 import Data.List as List
@@ -135,14 +135,14 @@ readOverlayByPackage tree =
     categories entries =
       [ (category, entries')
       | Directory dir entries' <- entries
-      , Just category <- [simpleParse dir] ]
+      , Just category <- [simpleParsec dir] ]
 
     packages :: Portage.Category -> DirectoryTree
              -> [(Portage.PackageName, DirectoryTree)]
     packages category entries =
       [ (Portage.PackageName category name, entries')
       | Directory dir entries' <- entries
-      , Just name <- [simpleParse dir] ]
+      , Just name <- [simpleParsec dir] ]
 
     versions :: Portage.PackageName -> DirectoryTree -> [Portage.Version]
     versions name@(Portage.PackageName (Portage.Category category) _) entries =
@@ -151,7 +151,7 @@ readOverlayByPackage tree =
       , let (baseName, ext) = splitExtension fileName
       , ext == ".ebuild"
       , let fullName = category ++ '/' : baseName
-      , Just (Portage.PackageId name' version) <- [simpleParse fullName]
+      , Just (Portage.PackageId name' version) <- [simpleParsec fullName]
       , name == name' ]
 
 readOverlay :: DirectoryTree -> [Portage.PackageId]

--- a/Portage/PackageId.hs
+++ b/Portage/PackageId.hs
@@ -125,11 +125,8 @@ toCabalPackageId (PackageId (PackageName _cat name) version) =
   fmap (Cabal.PackageIdentifier name)
            (Portage.toCabalVersion version)
 
-parseFriendlyPackage :: String -> Maybe (Maybe Category, Cabal.PackageName, Maybe Portage.Version)
-parseFriendlyPackage str =
-  case explicitEitherParsec parser str of
-    Right x -> Just x
-    Left _ -> Nothing
+parseFriendlyPackage :: String -> Either String (Maybe Category, Cabal.PackageName, Maybe Portage.Version)
+parseFriendlyPackage str = explicitEitherParsec parser str
   where
   parser = do
     mc <- P.optional . P.try $ do

--- a/Portage/Resolve.hs
+++ b/Portage/Resolve.hs
@@ -10,7 +10,7 @@ import qualified Portage.Overlay as Overlay
 import qualified Portage.PackageId as Portage
 
 import Distribution.Verbosity
-import Distribution.Text (display)
+import Distribution.Pretty (prettyShow)
 import qualified Distribution.Package as Cabal
 import Distribution.Simple.Utils
 
@@ -31,10 +31,10 @@ resolveCategory verbosity overlay pn = do
       return devhaskell
     [cat] -> do
       info verbosity $ "Exact match of already existing package, using category: "
-                         ++ display cat
+                         ++ prettyShow cat
       return cat
     cats -> do
-      warn verbosity $ "Multiple matches of categories: " ++ unwords (map display cats)
+      warn verbosity $ "Multiple matches of categories: " ++ unwords (map prettyShow cats)
       if devhaskell `elem` cats
         then do notice verbosity "Defaulting to dev-haskell"
                 return devhaskell

--- a/Portage/Use.hs
+++ b/Portage/Use.hs
@@ -13,7 +13,7 @@ module Portage.Use (
 
 import qualified Text.PrettyPrint as Disp
 import Text.PrettyPrint ((<>))
-import qualified Distribution.Text as DT
+import Distribution.Pretty (Pretty(..))
 
 #if MIN_VERSION_base(4,11,0)
 import Prelude hiding ((<>))
@@ -27,6 +27,9 @@ data UseFlag = UseFlag Use           -- ^ no modificator
              | N UseFlag             -- ^ - modificator 
              deriving (Eq,Show,Ord,Read)
 
+instance Pretty UseFlag where
+  pretty = showModificator
+
 mkUse :: Use -> UseFlag
 mkUse  = UseFlag 
 
@@ -36,23 +39,22 @@ mkNotUse = N . UseFlag
 mkQUse :: Use -> UseFlag
 mkQUse = Q . UseFlag
 
-instance DT.Text UseFlag where
-  disp = showModificator
-  parse = error "instance DT.Text UseFlag: not implemented"
-
 showModificator :: UseFlag -> Disp.Doc
-showModificator (UseFlag u) = DT.disp u
-showModificator (X u)     = Disp.char '!' <> DT.disp u
-showModificator (Q u)     = DT.disp u <> Disp.char '?'
-showModificator (E u)     = DT.disp u <> Disp.char '='
-showModificator (N u)     = Disp.char '-' <> DT.disp u
+showModificator (UseFlag u) = pretty u
+showModificator (X u)     = Disp.char '!' <> pretty u
+showModificator (Q u)     = pretty u <> Disp.char '?'
+showModificator (E u)     = pretty u <> Disp.char '='
+showModificator (N u)     = Disp.char '-' <> pretty u
 
 dispUses :: [UseFlag] -> Disp.Doc
 dispUses [] = Disp.empty
-dispUses us = Disp.brackets $ Disp.hcat $ (Disp.punctuate (Disp.text ", ")) $ map DT.disp  us
+dispUses us = Disp.brackets $ Disp.hcat $ (Disp.punctuate (Disp.text ", ")) $ map pretty us
 
 newtype Use = Use String
     deriving (Eq, Read, Show)
+
+instance Pretty Use where
+  pretty (Use u) = Disp.text u
 
 instance Ord Use where
     compare (Use a) (Use b) = case (a,b) of
@@ -60,7 +62,3 @@ instance Ord Use where
         ("test", _)      -> LT
         (_, "test")      -> GT
         (_, _)           -> a `compare` b
-
-instance DT.Text Use where
-    disp (Use u) = Disp.text u
-    parse = error "instance DT.Text Use: not implemented"

--- a/Status.hs
+++ b/Status.hs
@@ -31,7 +31,8 @@ import Control.Monad
 import qualified Distribution.Verbosity as Cabal
 import qualified Distribution.Package as Cabal (pkgName)
 import qualified Distribution.Simple.Utils as Cabal (comparing, die', equating)
-import qualified Distribution.Text as Cabal ( display, simpleParse )
+import Distribution.Pretty (prettyShow)
+import Distribution.Parsec.Class (simpleParsec)
 
 import qualified Distribution.Client.GlobalFlags as CabalInstall
 import qualified Distribution.Client.IndexUtils as CabalInstall
@@ -145,7 +146,7 @@ runStatus verbosity portdir overlaydir direction pkgs repoContext = do
                       PortagePlusOverlay -> id
                       HackageToOverlay   -> fromHackageFilter
   pkgs' <- forM pkgs $ \p ->
-            case Cabal.simpleParse p of
+            case simpleParsec p of
               Nothing -> Cabal.die' verbosity ("Could not parse package name: " ++ p ++ ". Format cat/pkg")
               Just pn -> return pn
   tree0 <- status verbosity portdir overlaydir repoContext
@@ -204,10 +205,10 @@ statusPrinter packages = do
         let (PackageName c p) = pkg
         putStr (bold (show ix))
         putStr " "
-        putStr $ Cabal.display c ++ '/' : bold (Cabal.display p)
+        putStr $ prettyShow c ++ '/' : bold (prettyShow p)
         putStr " "
         forM_ ebuilds $ \e -> do
-            putStr $ toColor (fmap (Cabal.display . pkgVersion . ebuildId) e)
+            putStr $ toColor (fmap (prettyShow . pkgVersion . ebuildId) e)
             putChar ' '
         putStrLn ""
 


### PR DESCRIPTION
`Distribution.Text` and `Distribution.Compat.ReadP` are deprecated, and in Cabal-3 the former has its typeclass entirely removed and the latter is removed entirely (or, more accurately, moved to a `Deprecated` module).

To aid in the eventual migration to Cabal-3 inside hackport, I've hacked away at porting our use of `Distribution.Text` to mainly two, separate modules: `Distribution.Pretty` for pretty printing, and `Distribution.Parsec.Class` for parsing. I've also used `Distribution.Compat.CharParsing` for helpful character parsing functions that are seemingly a drop-in replacement for the `Distribution.Compat.ReadP` parsing functions.

I have noticed no regressions with simple `hackport merge x` commands so far.

While this PR is fine to be merged as-is provided the design and implementation is okay with @trofi and others, `Portage.PackageId` still relies on `readP_to_S` to run the parser in the `parseFriendlyPackage` function. This is fine for the moment, but it will be a blocker to the eventual migration to Cabal-3 under the hood.

I'm happy to keep hacking away at a solution (which as far as I currently understand will use something from `Text.Parsec`) but I'm all ears to some guidance on this one, as I'm not all that familiar with Parsec.