### PR TITLE
Port to Cabal-3

### DIFF
--- a/Cabal2Ebuild.hs
+++ b/Cabal2Ebuild.hs
@@ -82,7 +82,7 @@ convertDependencies :: O.Overlay -> Portage.Category -> [Cabal.Dependency] -> [D
 convertDependencies overlay category = map (convertDependency overlay category)
 
 convertDependency :: O.Overlay -> Portage.Category -> Cabal.Dependency -> Dependency
-convertDependency overlay category (Cabal.Dependency pname versionRange)
+convertDependency overlay category (Cabal.Dependency pname versionRange _lib)
   = convert versionRange
   where
     pn = case Portage.resolveFullPortageName overlay pname of

--- a/Main.hs
+++ b/Main.hs
@@ -25,7 +25,7 @@ import Distribution.Verbosity (Verbosity, normal)
 
 import Data.Version (showVersion)
 import Distribution.Pretty (prettyShow)
-import Distribution.Parsec.Class (simpleParsec)
+import Distribution.Parsec (simpleParsec)
 
 import qualified Distribution.Client.Setup as CabalInstall
 import qualified Distribution.Client.Types as CabalInstall

--- a/Merge/Dependencies.hs
+++ b/Merge/Dependencies.hs
@@ -219,7 +219,7 @@ cabalDependency overlay pkg ~(Cabal.CompilerInfo {
          C2E.convertDependency overlay
                                (Portage.Category "dev-haskell")
                                (Cabal.Dependency (Cabal.mkPackageName "Cabal")
-                                                 finalCabalDep)
+                                                 finalCabalDep (S.singleton Cabal.defaultLibName))
   where
     versionNumbers = Cabal.versionNumbers cabal_version
     userCabalVersion = Cabal.orLaterVersion (Cabal.specVersion pkg)
@@ -429,7 +429,7 @@ buildToolsProvided = ["hsc2hs"]
 hackageBuildToolsDependencies :: Portage.Overlay -> Cabal.PackageDescription -> [Portage.Dependency]
 hackageBuildToolsDependencies overlay (Cabal.PackageDescription { Cabal.library = lib, Cabal.executables = exes }) =
   haskellDependencies overlay $ L.nub $
-    [ Cabal.Dependency pn versionRange
+    [ Cabal.Dependency pn versionRange $ S.singleton Cabal.defaultLibName
     | Cabal.ExeDependency pn _component versionRange <- cabalDeps
     ]
   where

--- a/Portage/Cabal.hs
+++ b/Portage/Cabal.hs
@@ -34,6 +34,6 @@ convertLicense l =
 
 partition_depends :: [Cabal.PackageName] -> Cabal.PackageName -> [Cabal.Dependency] -> ([Cabal.Dependency], [Cabal.Dependency])
 partition_depends ghc_package_names merged_cabal_pkg_name = L.partition (not . is_internal_depend)
-    where is_internal_depend (Cabal.Dependency pn _vr) = is_itself || is_ghc_package
+    where is_internal_depend (Cabal.Dependency pn _vr _lib) = is_itself || is_ghc_package
               where is_itself = pn == merged_cabal_pkg_name
                     is_ghc_package = pn `elem` ghc_package_names

--- a/Portage/GHCCore.hs
+++ b/Portage/GHCCore.hs
@@ -21,6 +21,7 @@ import Distribution.PackageDescription.Configuration
 import Distribution.Compiler (CompilerId(..), CompilerFlavor(GHC))
 import Distribution.System
 import Distribution.Types.ComponentRequestedSpec (defaultComponentRequestedSpec)
+import Distribution.Types.Dependency (depPkgName, depVerRange)
 
 import Distribution.Pretty (prettyShow)
 
@@ -66,9 +67,9 @@ packageIsCoreInAnyGHC pn = any (flip packageIsCore pn) (map snd ghcs)
 -- Packages that are not core will always be accepted, packages that are
 -- core in any ghc must be satisfied by the 'PackageIndex'.
 dependencySatisfiable :: InstalledPackageIndex -> Cabal.Dependency -> Bool
-dependencySatisfiable pindex dep@(Cabal.Dependency pn _rang)
+dependencySatisfiable pindex dep@(Cabal.Dependency pn _rang _lib)
   | Cabal.unPackageName pn == "Win32" = False -- only exists on windows, not in linux
-  | not . null $ lookupDependency pindex dep = True -- the package index satisfies the dep
+  | not . null $ lookupDependency pindex (depPkgName dep) (depVerRange dep) = True -- the package index satisfies the dep
   | packageIsCoreInAnyGHC pn = False -- some other ghcs support the dependency
   | otherwise = True -- the dep is not related with core packages, accept the dep
 

--- a/Portage/Overlay.hs
+++ b/Portage/Overlay.hs
@@ -16,7 +16,7 @@ import qualified Portage.Metadata as Portage
 
 import qualified Distribution.Package as Cabal
 
-import Distribution.Parsec.Class (simpleParsec)
+import Distribution.Parsec (simpleParsec)
 import Distribution.Simple.Utils ( comparing, equating )
 
 import Data.List as List

--- a/Portage/PackageId.hs
+++ b/Portage/PackageId.hs
@@ -20,7 +20,7 @@ module Portage.PackageId (
 
 import qualified Distribution.Package as Cabal
 
-import Distribution.Parsec.Class (CabalParsing(..), Parsec(..), explicitEitherParsec)
+import Distribution.Parsec (CabalParsing(..), Parsec(..), explicitEitherParsec)
 import qualified Distribution.Compat.CharParsing as P
 
 import qualified Portage.Version as Portage

--- a/Portage/Version.hs
+++ b/Portage/Version.hs
@@ -23,7 +23,7 @@ import qualified Distribution.Version as Cabal
 
 import Distribution.Pretty (Pretty(..))
 
-import Distribution.Parsec.Class (Parsec(..))
+import Distribution.Parsec (Parsec(..))
 import qualified Distribution.Compat.CharParsing as P
 import qualified Text.PrettyPrint as Disp
 import Text.PrettyPrint ((<>))

--- a/Status.hs
+++ b/Status.hs
@@ -32,7 +32,7 @@ import qualified Distribution.Verbosity as Cabal
 import qualified Distribution.Package as Cabal (pkgName)
 import qualified Distribution.Simple.Utils as Cabal (comparing, die', equating)
 import Distribution.Pretty (prettyShow)
-import Distribution.Parsec.Class (simpleParsec)
+import Distribution.Parsec (simpleParsec)
 
 import qualified Distribution.Client.GlobalFlags as CabalInstall
 import qualified Distribution.Client.IndexUtils as CabalInstall

--- a/hackport.cabal
+++ b/hackport.cabal
@@ -1,5 +1,5 @@
 Name:           hackport
-Version:        0.6.3
+Version:        0.6.4
 License:        GPL
 License-file:   LICENSE
 Author:         Henning Günther, Duncan Coutts, Lennart Kolmodin


### PR DESCRIPTION
This pull request ports `hackport` to use Cabal-3 under the hood. All in all very few changes were needed to make it work, and it builds successfully on ghc-8.6.5. I _assume_ that it will continue to build on ghc-8.0.2 from skimming `Cabal.cabal` on hackage.

These changes could benefit from wider testing, which is why I propose that we push this to master for -9999 users to try out. If all goes well, we could cut a release.

@trofi , if you're happy with the changes I'll push to hackport and the cabal submodule all together.