### PR TITLE
Add --refresh-metadata functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist-newstyle/
 cabal-dev/
 .ghc.environment*
 cabal.project.local
+report.html

--- a/Cabal2Ebuild.hs
+++ b/Cabal2Ebuild.hs
@@ -1,16 +1,16 @@
--- A program for generating a Gentoo ebuild from a .cabal file
---
--- Author : Duncan Coutts <dcoutts@gentoo.org>
---
--- Created: 21 July 2005
---
--- Copyright (C) 2005 Duncan Coutts
---
+{-|
+Module      : Cabal2Ebuild
+Copyright   : (C) 2005, Duncan Coutts
+License     : GPL-2+
+Maintainer  : haskell@gentoo.org
+
+A program for generating a Gentoo ebuild from a .cabal file
+-}
 -- This library is free software; you can redistribute it and/or
 -- modify it under the terms of the GNU General Public License
 -- as published by the Free Software Foundation; either version 2
 -- of the License, or (at your option) any later version.
---
+
 -- This library is distributed in the hope that it will be useful,
 -- but WITHOUT ANY WARRANTY; without even the implied warranty of
 -- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
@@ -43,6 +43,7 @@ import qualified Portage.EBuild as E
 import qualified Portage.Overlay as O
 import Portage.Version
 
+-- | Generate a 'Portage.EBuild' from a 'Portage.Category' and a 'Cabal.PackageDescription'.
 cabal2ebuild :: Portage.Category -> Cabal.PackageDescription -> Portage.EBuild
 cabal2ebuild cat pkg = Portage.ebuildTemplate {
     E.name        = Portage.cabal_pn_to_PN cabal_pn,
@@ -78,9 +79,11 @@ cabal2ebuild cat pkg = Portage.ebuildTemplate {
                          then E.homepage E.ebuildTemplate
                          else Cabal.homepage pkg
 
+-- | Map 'convertDependency' over ['Cabal.Dependency'].
 convertDependencies :: O.Overlay -> Portage.Category -> [Cabal.Dependency] -> [Dependency]
 convertDependencies overlay category = map (convertDependency overlay category)
 
+-- | Convert 'Cabal.Dependency' into 'Dependency'.
 convertDependency :: O.Overlay -> Portage.Category -> Cabal.Dependency -> Dependency
 convertDependency overlay category (Cabal.Dependency pname versionRange _lib)
   = convert versionRange

--- a/Error.hs
+++ b/Error.hs
@@ -5,6 +5,7 @@ module Error (HackPortError(..), throwEx, catchEx, hackPortShowError) where
 import Data.Typeable
 import Control.Exception.Extensible as EE
 
+-- | Type holding all of the 'HackPortError' constructors.
 data HackPortError
     = ArgumentError String
     | ConnectionFailed String String
@@ -30,12 +31,15 @@ data HackPortError
 
 instance Exception HackPortError where
 
+-- | Throw a 'HackPortError'.
 throwEx :: HackPortError -> IO a
 throwEx = EE.throw
 
+-- | Catch a 'HackPortError'.
 catchEx :: IO a -> (HackPortError -> IO a) -> IO a
 catchEx = EE.catch
 
+-- | Show the error string for a given 'HackPortError'.
 hackPortShowError :: HackPortError -> String
 hackPortShowError err = case err of
     ArgumentError str -> "Argument error: "++str

--- a/HackPort/GlobalFlags.hs
+++ b/HackPort/GlobalFlags.hs
@@ -17,6 +17,7 @@ import System.FilePath ((</>))
 
 import qualified Overlays
 
+-- | Type containing global flags.
 data GlobalFlags =
     GlobalFlags { globalVersion :: DSS.Flag Bool
                 , globalNumericVersion :: DSS.Flag Bool
@@ -24,6 +25,7 @@ data GlobalFlags =
                 , globalPathToPortage :: DSS.Flag (Maybe FilePath)
                 }
 
+-- | Default 'GlobalFlags'.
 defaultGlobalFlags :: GlobalFlags
 defaultGlobalFlags =
     GlobalFlags { globalVersion = DSS.Flag False
@@ -32,6 +34,7 @@ defaultGlobalFlags =
                 , globalPathToPortage = DSS.Flag Nothing
                 }
 
+-- | Default remote repository. Defaults to [hackage](hackage.haskell.org).
 defaultRemoteRepo :: DCT.RemoteRepo
 defaultRemoteRepo = DCC.addInfoForKnownRepos $ (DCT.emptyRemoteRepo name) { DCT.remoteRepoURI = uri }
    where

--- a/Merge.hs
+++ b/Merge.hs
@@ -214,12 +214,22 @@ first_just_of = msum
 -- | Gentoo allows underscore ('_') names in @IUSE@ only for
 -- @USE_EXPAND@ values. If it's not a user-specified rename mangle
 -- it into a hyphen ('-').
+-- 
+-- >>> mangle_iuse "use_remove_my_underscores"
+-- "remove-my-underscores"
 mangle_iuse :: String -> String
 mangle_iuse = drop_prefix . map f
   where f '_' = '-'
         f c   = c
 
 -- | Remove @with@ or @use@ prefixes from flag names.
+--
+-- >>> drop_prefix "with_conduit"
+-- "conduit"
+-- >>> drop_prefix "use-https"
+-- "https"
+-- >>> drop_prefix "no_examples"
+-- "no_examples"
 drop_prefix :: String -> String
 drop_prefix x
   | take 5 x `elem` ["with_","with-"] = drop 5 x
@@ -487,8 +497,14 @@ withWorkingDirectory newDir action = do
     (\_ -> action)
 
 -- | Convert all stable keywords to testing (unstable) keywords.
+-- Preserve arch masks (-).
 --
--- > to_unstable "amd64" = "~amd64"
+-- >>> to_unstable "amd64"
+-- "~amd64"
+-- >>> to_unstable "~amd64"
+-- "~amd64"
+-- >>> to_unstable "-amd64"
+-- "-amd64"
 to_unstable :: String -> String
 to_unstable kw =
     case kw of

--- a/Merge/Dependencies.hs
+++ b/Merge/Dependencies.hs
@@ -1,7 +1,11 @@
-{-# LANGUAGE CPP #-}
+{-|
+Module      : Merge.Dependencies
+License     : GPL-3+
+Maintainer  : haskell@gentoo.org
 
-{- | Merge a package from hackage to an ebuild.
- -}
+Merge a package from @hackage@ to an ebuild.
+-}
+{-# LANGUAGE CPP #-}
 module Merge.Dependencies
   ( EDep(..)
   , RetroPackageDescription(..)
@@ -42,7 +46,7 @@ import Debug.Trace ( trace )
 import Data.Semigroup (Semigroup(..))
 #endif
 
--- | Dependencies of an ebuild
+-- | Dependencies of an ebuild.
 data EDep = EDep
   {
     rdep :: Portage.Dependency,
@@ -52,17 +56,17 @@ data EDep = EDep
   }
   deriving (Show, Eq, Ord)
 
--- | Cabal-1 style PackageDescription, with a top-level buildDepends function
+-- | Cabal-1 style 'Cabal.PackageDescription', with a top-level 'buildDepends' function.
 data RetroPackageDescription = RetroPackageDescription {
   packageDescription :: Cabal.PackageDescription,
   buildDepends :: [Cabal.Dependency]
   } deriving (Show)
 
--- | Construct a RetroPackageDescription using exeAndLibDeps for the buildDepends.
+-- | Construct a 'RetroPackageDescription' using 'exeAndLibDeps' for the 'buildDepends'.
 mkRetroPD :: Cabal.PackageDescription -> RetroPackageDescription
 mkRetroPD pd = RetroPackageDescription { packageDescription = pd, buildDepends = exeAndLibDeps pd }
 
--- | extract only the build dependencies for libraries and executables for a given package.
+-- | Extract only the build dependencies for libraries and executables for a given package.
 exeAndLibDeps :: Cabal.PackageDescription -> [Cabal.Dependency]
 exeAndLibDeps pkg = L.union
                     (concat
@@ -99,6 +103,7 @@ instance Monoid EDep where
     }
 #endif
 
+-- | Resolve package dependencies from a 'RetroPackageDescription' into an 'EDep'.
 resolveDependencies :: Portage.Overlay -> RetroPackageDescription -> Cabal.CompilerInfo
                     -> [Cabal.PackageName] -> Cabal.PackageName
                     -> EDep

--- a/Portage/Cabal.hs
+++ b/Portage/Cabal.hs
@@ -13,12 +13,25 @@ module Portage.Cabal
 
 import qualified Data.List as L
 
-import qualified Distribution.License             as Cabal
-import qualified Distribution.SPDX.License        as SPDX
-import qualified Distribution.Package             as Cabal
-import qualified Distribution.Pretty                as Cabal
+import qualified Distribution.License as Cabal
+import qualified Distribution.SPDX    as SPDX
+import qualified Distribution.Package as Cabal
+import qualified Distribution.Pretty  as Cabal
 
--- | Convert the Cabal 'SPDX.License' to the Gentoo license format, as a 'String'.
+-- | Convert the Cabal 'SPDX.License' into the Gentoo format, as a 'String'.
+--
+-- Generally, if the license is one of the common free-software or
+-- open-source licenses, 'convertLicense' should return the license
+-- as a 'Right' 'String':
+--
+-- >>> convertLicense (SPDX.License $ SPDX.simpleLicenseExpression SPDX.GPL_3_0_or_later)
+-- Right "GPL-3.0"
+--
+-- If it is a more obscure license, this should alert the user by returning
+-- a 'Left' 'String':
+--
+-- >>> convertLicense (SPDX.License $ SPDX.simpleLicenseExpression SPDX.EUPL_1_1)
+-- Left ...
 convertLicense :: SPDX.License -> Either String String
 convertLicense l =
     case Cabal.licenseFromSPDX l of

--- a/Portage/Cabal.hs
+++ b/Portage/Cabal.hs
@@ -1,3 +1,11 @@
+{-|
+Module      : Portage.Cabal
+License     : GPL-3+
+Maintainer  : haskell@gentoo.org
+
+Utilities to extract and manipulate information from a package's @.cabal@ file,
+such as its license and dependencies.
+-}
 module Portage.Cabal
   ( convertLicense
   , partition_depends
@@ -10,7 +18,7 @@ import qualified Distribution.SPDX.License        as SPDX
 import qualified Distribution.Package             as Cabal
 import qualified Distribution.Pretty                as Cabal
 
--- map the cabal license type to the gentoo license string format
+-- | Convert the Cabal 'SPDX.License' to the Gentoo license format, as a 'String'.
 convertLicense :: SPDX.License -> Either String String
 convertLicense l =
     case Cabal.licenseFromSPDX l of
@@ -32,6 +40,7 @@ convertLicense l =
         Cabal.OtherLicense      -> Left "(Other) Please look at license file of package and pick it manually."
         Cabal.UnspecifiedLicense -> Left "(Unspecified) Please look at license file of package and pick it manually."
 
+-- | Extract only the dependencies which are not bundled with @GHC@.
 partition_depends :: [Cabal.PackageName] -> Cabal.PackageName -> [Cabal.Dependency] -> ([Cabal.Dependency], [Cabal.Dependency])
 partition_depends ghc_package_names merged_cabal_pkg_name = L.partition (not . is_internal_depend)
     where is_internal_depend (Cabal.Dependency pn _vr _lib) = is_itself || is_ghc_package

--- a/Portage/Dependency/Types.hs
+++ b/Portage/Dependency/Types.hs
@@ -1,3 +1,10 @@
+{-|
+Module      : Portage.Dependency.Types
+License     : GPL-3+
+Maintainer  : haskell@gentoo.org
+
+Functions and types related to processing Portage dependencies.
+-}
 module Portage.Dependency.Types
   (
     SlotDepend(..)
@@ -16,14 +23,16 @@ module Portage.Dependency.Types
 import Portage.PackageId
 import Portage.Use
 
-data SlotDepend = AnySlot          -- nothing special
-                | AnyBuildTimeSlot -- ':='
-                | GivenSlot String -- ':slotno'
+-- | Type of SLOT dependency of a dependency.
+data SlotDepend = AnySlot          -- ^ nothing special
+                | AnyBuildTimeSlot -- ^ ':='
+                | GivenSlot String -- ^ ':slotno'
     deriving (Eq, Show, Ord)
 
-data LBound = StrictLB    Version
-            | NonstrictLB Version
-            | ZeroB
+-- | Type of lower bound of a dependency.
+data LBound = StrictLB    Version -- ^ greater than (>)
+            | NonstrictLB Version -- ^ greater than or equal to (>=)
+            | ZeroB               -- ^ no lower bound
     deriving (Eq, Show)
 
 instance Ord LBound where
@@ -38,10 +47,10 @@ instance Ord LBound where
     compare (NonstrictLB lv) (StrictLB rv)    = case compare lv rv of
                                                     EQ -> LT
                                                     r  -> r
-
-data UBound = StrictUB Version   -- <
-            | NonstrictUB Version -- <=
-            | InfinityB
+-- | Type of upper bound of a dependency.
+data UBound = StrictUB Version    -- ^ less than (<)
+            | NonstrictUB Version -- ^ less than or equal to (<=)
+            | InfinityB           -- ^ no upper bound
     deriving (Eq, Show)
 
 instance Ord UBound where
@@ -57,6 +66,10 @@ instance Ord UBound where
                                                     EQ -> GT
                                                     r  -> r
 
+-- | Type of dependency version.
+--
+-- A dependency version may either be an exact 'Version' or a
+-- version range between a given 'LBound' and 'UBound'.
 data DRange = DRange LBound UBound
             | DExact Version
     deriving (Eq, Show, Ord)
@@ -66,7 +79,7 @@ range_is_case_of (DRange llow lup) (DRange rlow rup)
    | llow >= rlow && lup <= rup = True
 range_is_case_of _ _ = False
 
--- True if 'left' "interval" covers at least as much as the 'right' "interval"
+-- | True if left 'DRange' covers at least as much as the right 'DRange'.
 range_as_broad_as :: DRange -> DRange -> Bool
 range_as_broad_as (DRange llow lup) (DRange rlow rup)
     | llow <= rlow && lup >= rup = True
@@ -83,7 +96,8 @@ data Dependency = DependAtom Atom
 
 data Atom = Atom PackageName DRange DAttr deriving (Eq, Show, Ord)
 
--- returns 'True' if left constraint is the same as (or looser than) right
+-- | True if left 'Dependency' constraint is the same as (or looser than) right
+-- 'Dependency' constraint.
 dep_as_broad_as :: Dependency -> Dependency -> Bool
 dep_as_broad_as l r
     -- very broad (not only on atoms) special case

--- a/Portage/EBuild.hs
+++ b/Portage/EBuild.hs
@@ -1,3 +1,11 @@
+{-|
+Module      : Portage.EBuild
+License     : GPL-3+
+Maintainer  : haskell@gentoo.org
+
+Functions and types related to interpreting and manipulating an ebuild,
+as understood by the Portage package manager.
+-}
 {-# LANGUAGE CPP #-}
 module Portage.EBuild
         ( EBuild(..)
@@ -23,6 +31,7 @@ import qualified Paths_hackport(version)
 import qualified System.Locale as TC
 #endif
 
+-- | Type representing the information contained in an @.ebuild@.
 data EBuild = EBuild {
     name :: String,
     category :: String,
@@ -52,6 +61,7 @@ getHackportVersion :: Version -> String
 getHackportVersion Version {versionBranch=(x:s)} = foldl (\y z -> y ++ "." ++ (show z)) (show x) s
 getHackportVersion Version {versionBranch=[]} = ""
 
+-- | Generate a minimal 'EBuild' template.
 ebuildTemplate :: EBuild
 ebuildTemplate = EBuild {
     name = "foobar",
@@ -89,6 +99,7 @@ src_uri e =
     -- package
     Just _  -> "https://hackage.haskell.org/package/${MY_P}/${MY_P}.tar.gz"
 
+-- | Pretty-print an 'EBuild' as a 'String'.
 showEBuild :: TC.UTCTime -> EBuild -> String
 showEBuild now ebuild =
   ss ("# Copyright 1999-" ++ this_year ++ " Gentoo Authors"). nl.
@@ -147,7 +158,7 @@ showEBuild now ebuild =
 sort_iuse :: [String] -> [String]
 sort_iuse = L.sortBy (compare `F.on` dropWhile ( `elem` "+"))
 
--- drops trailing dot
+-- | Drop trailing dot.
 drop_tdot :: String -> String
 drop_tdot = reverse . dropWhile (== '.') . reverse
 
@@ -215,18 +226,16 @@ sepBy _ []     = id
 sepBy _ [x]    = ss x
 sepBy s (x:xs) = ss x. ss s. sepBy s xs
 
-getRestIfPrefix ::
-    String ->    -- ^ the prefix
-    String ->    -- ^ the string
-    Maybe String
+getRestIfPrefix :: String       -- ^ the prefix
+                -> String       -- ^ the string
+                -> Maybe String
 getRestIfPrefix (p:ps) (x:xs) = if p==x then getRestIfPrefix ps xs else Nothing
 getRestIfPrefix [] rest = Just rest
 getRestIfPrefix _ [] = Nothing
 
-subStr ::
-    String ->    -- ^ the search string
-    String ->    -- ^ the string to be searched
-    Maybe (String,String)  -- ^ Just (pre,post) if string is found
+subStr :: String                -- ^ the search string
+       -> String                -- ^ the string to be searched
+       -> Maybe (String,String) -- ^ Just (pre,post) if string is found
 subStr sstr str = case getRestIfPrefix sstr str of
     Nothing -> if null str then Nothing else case subStr sstr (tail str) of
         Nothing -> Nothing
@@ -234,9 +243,9 @@ subStr sstr str = case getRestIfPrefix sstr str of
     Just rest -> Just ([],rest)
 
 replaceMultiVars ::
-    [(String,String)] ->    -- ^ pairs of variable name and content
-    String ->        -- ^ string to be searched
-    String             -- ^ the result
+    [(String,String)] -- ^ pairs of variable name and content
+    -> String         -- ^ string to be searched
+    -> String         -- ^ the result
 replaceMultiVars [] str = str
 replaceMultiVars whole@((pname,cont):rest) str = case subStr cont str of
     Nothing -> replaceMultiVars rest str

--- a/Portage/EBuild.hs
+++ b/Portage/EBuild.hs
@@ -89,6 +89,9 @@ ebuildTemplate = EBuild {
 
 -- | Given an EBuild, give the URI to the tarball of the source code.
 -- Assumes that the server is always hackage.haskell.org.
+-- 
+-- >>> src_uri ebuild_template
+-- "https://hackage.haskell.org/package/${P}/${P}.tar.gz"
 src_uri :: EBuild -> String
 src_uri e =
   case my_pn e of
@@ -153,12 +156,17 @@ showEBuild now ebuild =
         this_year = TC.formatTime TC.defaultTimeLocale "%Y" now
         replace old new = L.intercalate new . LS.splitOn old
 
--- "+a" -> "a"
--- "b"  -> "b"
+-- | Sort IUSE, and drop leading pluses (+)
+--
+-- >>> sort_iuse ["+a","b"]
+-- ["a","b"]
 sort_iuse :: [String] -> [String]
 sort_iuse = L.sortBy (compare `F.on` dropWhile ( `elem` "+"))
 
 -- | Drop trailing dot.
+--
+-- >>> drop_tdot "foo."
+-- "foo"
 drop_tdot :: String -> String
 drop_tdot = reverse . dropWhile (== '.') . reverse
 
@@ -206,6 +214,10 @@ dep_str var extra dep = ss var. sc '='. quote' (ss $ drop_leadings $ unlines ext
           deps_s = tabify (dep2str indent $ PN.normalize_depend dep)
           drop_leadings = dropWhile (== '\t')
 
+-- | Place a 'String' between quotes, and correctly handle special characters.
+--
+-- FIXME: special characters aren't correctly handled.
+-- See [hackport issue #36](https://github.com/gentoo-haskell/hackport/issues/36)
 quote :: String -> DString
 quote str = sc '"'. ss (esc str). sc '"'
   where

--- a/Portage/EBuild/CabalFeature.hs
+++ b/Portage/EBuild/CabalFeature.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE LambdaCase #-}
 
--- CABAL_FEATURES="..." in haskell-cabal .ebuild files
--- see haskell-cabal.eclass for details on each of those
+-- | Support for CABAL_FEATURES="..." in haskell-cabal .ebuild files.
+-- See haskell-cabal.eclass for details on each of those.
 module Portage.EBuild.CabalFeature (CabalFeature(..)) where
 
 import Portage.EBuild.Render
 
+-- | Type representing @CABAL_FEATURES@ in an ebuild.
 data CabalFeature = Lib
                   | Profile
                   | Haddock

--- a/Portage/Metadata.hs
+++ b/Portage/Metadata.hs
@@ -1,34 +1,71 @@
 module Portage.Metadata
         ( Metadata(..)
         , metadataFromFile
+        , pureMetadataFromFile
+        , prettyPrintFlagsHuman
         , makeDefaultMetadata
+        , makeMinimalMetadata
         ) where
 
-import qualified Data.ByteString as B
+import qualified AnsiColor as A
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Data.Map.Strict as Map
 
 import Text.XML.Light
 
-newtype Metadata = Metadata
-      { metadata_emails :: [String]
-      -- , metadataMaintainers :: [String],
-      -- , metadataUseFlags :: [(String,String)]
+data Metadata = Metadata
+      { metadataEmails :: [String]
+      , metadataUseFlags :: Map.Map String String
+      -- , metadataMaintainers :: [String]
       } deriving (Show)
 
-metadataFromFile :: FilePath -> IO (Maybe Metadata)
-metadataFromFile fp = do
-  doc <- parseXMLDoc <$> B.readFile fp
-  return (doc >>= parseMetadata)
+-- | Maybe return a Metadata from a Text string
+pureMetadataFromFile :: T.Text -> Maybe Metadata
+pureMetadataFromFile file = parseXMLDoc file >>= \doc -> parseMetadata doc
 
+-- | Apply @pureMetadataFromFile@ to a FilePath
+metadataFromFile :: FilePath -> IO (Maybe Metadata)
+metadataFromFile fp = pureMetadataFromFile <$> T.readFile fp
+
+-- | Extract the maintainer email and USE flags from a supplied XML Element
 parseMetadata :: Element -> Maybe Metadata
 parseMetadata xml =
-  return Metadata { metadata_emails = map strContent (findElements (unqual "email") xml) }
+  return Metadata { metadataEmails = strContent <$> findElements (unqual "email") xml
+                  , metadataUseFlags =
+                      -- find the flag name
+                      let x = findElement (unqual "use") xml
+                          y = onlyElems $ concatMap elContent x
+                          z = attrVal <$> concatMap elAttribs y
+                      -- find the flag description
+                          a = concatMap elContent y
+                          b = cdData <$> onlyText a
+                        in Map.fromList $ zip z b
+                  }
 
-formatFlags :: (String, String) -> String
-formatFlags (name, description) = "\t\t<flag name=\"" ++ name ++
-                                  "\">" ++ description ++ "</flag>"
+-- | Pretty print as valid XML a list of flags and their descriptions
+-- from a given strict map.
+prettyPrintFlags :: Map.Map String String -> [String]
+prettyPrintFlags m = (\(name,description) -> "\t\t<flag name=\"" ++ name ++
+                                          "\">" ++ description ++ "</flag>")
+                     <$> Map.toAscList m
+
+-- | Pretty print a human-readable list of flags and their descriptions
+-- from a given strict map.
+prettyPrintFlagsHuman :: Map.Map String String -> [String]
+prettyPrintFlagsHuman m = (\(name,description) -> A.bold (name ++ ": ") ++ description)
+                          <$> Map.toAscList m
+                          
+-- | A minimal metadata for use as a fallback value
+makeMinimalMetadata :: Metadata
+makeMinimalMetadata = Metadata { metadataEmails = ["haskell@gentoo.org"]
+                               , metadataUseFlags = Map.empty
+                               }
 
 -- don't use Text.XML.Light as we like our own pretty printer
-makeDefaultMetadata :: String -> [(String, String)] -> String
+-- | Pretty print the metadata.xml file
+makeDefaultMetadata :: String -> Map.Map String String -> String
 makeDefaultMetadata long_description flags =
     unlines [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
             , "<!DOCTYPE pkgmetadata SYSTEM \"http://www.gentoo.org/dtd/metadata.dtd\">"
@@ -37,10 +74,7 @@ makeDefaultMetadata long_description flags =
             , "\t\t<email>haskell@gentoo.org</email>"
             , "\t\t<name>Gentoo Haskell</name>"
             , "\t</maintainer>"
-            , if (formatFlags <$> flags) == [""]
-              then "\t<use>\n\t</use>"
-              else "\t<use>\n" ++ (unlines $ formatFlags <$> flags) ++
-                   "\t</use>"
+            , "\t<use>\n" ++ (unlines $ prettyPrintFlags flags) ++ "\t</use>"
             , (init {- strip trailing newline-}
               . unlines
               . map (\l -> if l `elem` ["<longdescription>", "</longdescription>"]

--- a/Portage/Overlay.hs
+++ b/Portage/Overlay.hs
@@ -40,12 +40,14 @@ instance Cabal.Package ExistingEbuild where
 instance Cabal.HasUnitId ExistingEbuild where
     installedUnitId _ = error "Portage.Cabal.installedUnitId: FIXME: should not be used"
 
+-- | Type describing an overlay.
 data Overlay = Overlay {
     overlayPath  :: FilePath,
     overlayMap :: Map Portage.PackageName [ExistingEbuild],
     overlayMetadata :: Map Portage.PackageName Portage.Metadata
   } deriving Show
 
+-- | Is 'Cabal.PackageId' found in 'Overlay'?
 inOverlay :: Overlay -> Cabal.PackageId -> Bool
 inOverlay overlay pkgId = not (Map.null packages)
   where
@@ -110,7 +112,7 @@ filterByEmail p overlay = overlay
     pkgMap' = Map.intersection (overlayMap overlay) metadataMap'
 
 
--- make sure there is only one ebuild for each version number (by selecting
+-- | Make sure there is only one ebuild for each version number (by selecting
 -- the highest ebuild version revision)
 reduceOverlay :: Overlay -> Overlay
 reduceOverlay overlay = overlay { overlayMap = Map.map reduceVersions (overlayMap overlay) }

--- a/Portage/Overlay.hs
+++ b/Portage/Overlay.hs
@@ -106,7 +106,7 @@ filterByEmail p overlay = overlay
                             , overlayMap = pkgMap'
                             }
   where
-    metadataMap' = Map.filter (p . Portage.metadata_emails) (overlayMetadata overlay)
+    metadataMap' = Map.filter (p . Portage.metadataEmails) (overlayMetadata overlay)
     pkgMap' = Map.intersection (overlayMap overlay) metadataMap'
 
 

--- a/Portage/Tables.hs
+++ b/Portage/Tables.hs
@@ -1,4 +1,10 @@
--- | Tables of portage specific convertations
+{-|
+Module      : Portage.Tables
+License     : GPL-3+
+Maintainer  : haskell@gentoo.org
+
+Tables of Portage-specific conversions.
+-}
 module Portage.Tables
   ( set_build_slot
   ) where
@@ -9,6 +15,7 @@ import Portage.PackageId
 
 import Data.Monoid
 
+-- | Set the @SLOT@ for a given 'Dependency'.
 set_build_slot :: Dependency -> Dependency
 set_build_slot = 
   overAtom $ \a@(Atom pn dr (DAttr _ u)) -> 
@@ -20,6 +27,9 @@ set_build_slot =
         | pn == nm  = Just s
         | otherwise = Nothing
 
+-- | List of 'PackageName's with their corresponding default 'SlotDepend's.
+--
+-- For example, dependency @QuickCheck@ has its @SLOT@ always set to @2@.
 slottedPkgs :: [(PackageName, SlotDepend)]
 slottedPkgs =
   [ (mkPackageName "dev-haskell" "quickcheck", GivenSlot "2=")

--- a/Portage/Version.hs
+++ b/Portage/Version.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-
 {-|
     Author      :  Andres Loeh <kosmikus@gentoo.org>
     Stability   :  provisional
@@ -34,10 +33,11 @@ import qualified Data.List.NonEmpty as NonEmpty
 import Prelude hiding ((<>))
 #endif
 
-data Version = Version { versionNumber   :: [Int]        -- [1,42,3] ~= 1.42.3
-                       , versionChar     :: (Maybe Char) -- optional letter
+-- | Portage-style version type.
+data Version = Version { versionNumber   :: [Int]        -- ^ @[1,42,3]@ ~= 1.42.3
+                       , versionChar     :: (Maybe Char) -- ^ optional letter
                        , versionSuffix   :: [Suffix]
-                       , versionRevision :: Int          -- revision, 0 means none
+                       , versionRevision :: Int          -- ^ revision, 0 means none
                        }
   deriving (Eq, Ord, Show, Read)
 
@@ -61,6 +61,7 @@ instance Parsec Version where
   
 -- foo-9999* is treated as live ebuild
 -- Cabal-1.17.9999* as well
+-- | Check if the ebuild is a live ebuild, i.e. its 'Version' is @9999@.
 is_live :: Version -> Bool
 is_live v =
     case vs of
@@ -72,6 +73,7 @@ is_live v =
         is_big n     = n >= 9999
         all_nines n  = (all (== '9') . show) n
 
+-- | Various allowed suffixes in Portage versions.
 data Suffix = Alpha Int | Beta Int | Pre Int | RC Int | P Int
   deriving (Eq, Ord, Show, Read)
 
@@ -100,12 +102,15 @@ instance Parsec Suffix where
     where
       maybeDigits = P.option 0 digits
 
+-- | Convert from a 'Cabal.Version' to a Portage 'Version'.
 fromCabalVersion :: Cabal.Version -> Version
 fromCabalVersion cabal_version = Version (Cabal.versionNumbers cabal_version) Nothing [] 0
 
+-- | Convert from a Portage 'Version' to a 'Cabal.Version'.
 toCabalVersion :: Version -> Maybe Cabal.Version
 toCabalVersion (Version nums Nothing [] _) = Just (Cabal.mkVersion nums)
 toCabalVersion _                           = Nothing
 
+-- | Parser which munches digits.
 digits :: P.CharParsing m => m Int
 digits = read <$> P.munch1 Char.isDigit

--- a/hackport.cabal
+++ b/hackport.cabal
@@ -447,6 +447,16 @@ Executable    hackport
     Prelude
     Text.JSON.Canonical
 
+test-suite doctests
+  type:             exitcode-stdio-1.0
+  ghc-options:      -threaded
+  default-language: Haskell98
+  main-is:          tests/doctests.hs
+  build-depends:    base,
+                    doctest >= 0.8,
+                    template-haskell,
+                    QuickCheck
+
 Test-Suite test-resolve-category
   ghc-options: -Wall
   Type:                 exitcode-stdio-1.0

--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -1,0 +1,12 @@
+module Main where
+
+import Test.DocTest
+-- Some modules fail to find module Paths_hackport, which is generated during building.
+-- There is a way to make this work properly, but for now just test modules which
+-- don't import Paths_hackport.
+main = doctest [ "Portage/Cabal.hs"
+               , "Portage/GHCCore.hs"
+               , "Portage/PackageId.hs"
+               , "Portage/Version.hs"
+               , "Portage/Metadata.hs"
+               ]


### PR DESCRIPTION
The general gist of the new functionality is this:

1. If a new package version contains new USE flags, alphabetically insert them into the `metadata.xml`
2. If a new package version updates the description of an existing USE flag, overwrite the old description
3. Control (1) and (2) with a boolean flag (e.g. `--refresh-metadata`)

As it stands, (1) and (2) are complete and work as expected, thus this PR can be used for testing (note that commits will be squashed prior to the final merge). **(3) is outstanding**, so currently the functionality is hard enabled. This is partly because I wanted to first focus on getting that right before focusing on the switchable flag side of things, and partly because I'm completely unfamiliar with how we use `Cabal`'s argparser in `HackPort`.

This is a more verbose list of changes in this PR:
- Extend the `Metadata` type to contain a strict `Map` of flag names and their descriptions
- Update ancillary functions to work on strict `Map`s rather than lists of tuples (of flag names and descriptions)
- Use the `Text` type in place of `ByteString`s for writing UTF-8 `metadata.xml` files and ebuilds (this was previously achieved with `ByteString` builders, but using `Text` is both more readable and 'correct', according to the `bytestring` maintainers)
- Update the `parseMetadata` function to correctly read flag names and their descriptions, and write them as a strict map
- Add a `pureMetadataFromFile` function to directly parse from a `Text` string, rather than from a `FilePath`. Use this function internally in the existing `metadataFromFile` to avoid duplication
- Add `makeMinimalMetadata` as a fallback Metadata object. This is used as the default value where I use `fromMaybe` in `Merge.hs`
- Comment the code rather verbosely.

**TODO**
- Switch the functionality using a flag (say, `-m/--refresh-metadata`) in `Main.hs`. I am **not** familiar with how we use `Cabal`'s argparser, so this might take a bit of time or end up being a roadblock for a while.
- Go over the code and see if we can clean up anything. One such candidate is `current_meta` and `current_meta'` in `Merge.hs`.

Closes: #68 