### PR TITLE
Merge/Dependencies, Portage/EBuild.hs: generate BDEPEND

### DIFF
--- a/Merge/Dependencies.hs
+++ b/Merge/Dependencies.hs
@@ -140,11 +140,12 @@ resolveDependencies overlay pkg compiler_info ghc_package_names merged_cabal_pkg
                   {
                     dep = Portage.DependAllOf
                               [ cabal_dep
+                              , ghc_dep
                               , setup_deps
                               , build_tools
                               , test_deps
                               ],
-                    dep_e = S.singleton "${RDEPEND}",
+                    dep_e = S.empty,
                     rdep = Portage.DependAllOf
                                [ Portage.set_build_slot ghc_dep
                                , Portage.set_build_slot $ add_profile $ raw_haskell_deps
@@ -156,11 +157,12 @@ resolveDependencies overlay pkg compiler_info ghc_package_names merged_cabal_pkg
                   {
                     dep = Portage.DependAllOf
                               [ cabal_dep
+                              , ghc_dep
                               , setup_deps
                               , build_tools
                               , test_deps
                               ],
-                    dep_e = S.singleton "${RDEPEND}",
+                    dep_e = S.empty,
                     rdep = Portage.DependAllOf
                                [ Portage.set_build_slot ghc_dep
                                , Portage.set_build_slot $ raw_haskell_deps

--- a/Portage/EBuild.hs
+++ b/Portage/EBuild.hs
@@ -136,7 +136,8 @@ showEBuild now ebuild =
   ss "IUSE=". quote' (sepBy " " . sort_iuse $ L.nub $ iuse ebuild). nl.
   nl.
   dep_str "RDEPEND" (rdepend_extra ebuild) (rdepend ebuild).
-  dep_str "DEPEND"  ( depend_extra ebuild) ( depend ebuild).
+  ss "DEPEND=\"${RDEPEND}\"". nl.
+  dep_str "BDEPEND"  ( depend_extra ebuild) ( depend ebuild).
   (case my_pn ebuild of
      Nothing -> id
      Just _ -> nl. ss "S=". quote ("${WORKDIR}/${MY_P}"). nl).


### PR DESCRIPTION
First of all, I think making this change will require us specifying `ghc` both under `RDEPEND` for its provision of core libraries and under `BDEPEND` as the compiler. I won't assume that that's automatically something we want to do, but it's possible to do. This patch ~~does _not_ currently do this~~ implements this behaviour, and I do not open this pull request on the assumption that this behaviour is worth implementing, but the rest of the pull request is regardless written as if it is something we want to do.

I will note that it is not immediately clear to me what should be in `DEPEND` other than `${RDEPEND}`. The way I understand this is that we dynamically link our libraries, putting them under `RDEPEND` (including `ghc`), and our test dependencies and dependency on `cabal` are only required on the build machine, but not necessarily the installation machine. If this is correct, and will always be correct, then I believe this tiny patch should suffice.

This patch makes trivial changes by:

  1. Printing a hardcoded `DEPEND="${RDEPEND}"` into the ebuild where we previously generated the `DEPEND` list. We will always want `${RDEPEND}` inside `DEPEND`. The other large assumption this patch makes is that nothing else wants to be in `DEPEND`. If we can safely assume that this is _always_ right, then this should be fine. Otherwise this patch will require rearchitecting. The only other change in Portage/EBuild.hs is renaming the existing `DEPEND` line to read `BDEPEND`, so that we can utilise the existing dependency generation infrastructure without being too invasive with code changes.

  2. Removing `"${RDEPEND}"` from the newly-renamed `BDEPEND` in Merge/Dependencies.hs, since unlike `DEPEND`, `BDEPEND` should not include `RDEPEND`. Also add the `ghc` dependency under `BDEPEND` as compiler rather than as provider of core libraries.

Closes: https://github.com/gentoo-haskell/hackport/issues/70