### PR TITLE
tree-wide: warn user if bumping a ::gentoo package

### DIFF
--- a/Portage/PackageId.hs
+++ b/Portage/PackageId.hs
@@ -46,7 +46,7 @@ data PackageName = PackageName { category :: Category, cabalPkgName :: Cabal.Pac
   deriving (Eq, Ord, Show, Read)
 
 -- | Portage-style 'PackageId', containing a 'PackageName' and a 'Portage.Version'.
-data PackageId = PackageId { packageId :: PackageName, pkgVersion :: Portage.Version }
+data PackageId = PackageId { pkgName :: PackageName, pkgVersion :: Portage.Version }
   deriving (Eq, Ord, Show, Read)
 
 instance Pretty Category where
@@ -94,7 +94,7 @@ packageIdToFilePath (PackageId (PackageName cat pn) version) =
 -- file extension stripped before being passed to 'filePathToPackageId'.
 -- 
 -- >>> filePathToPackageId (Category "dev-haskell") "foo-bar2-3.0.0b_rc2-r1"
--- Just (PackageId {packageId = PackageName {category = Category {unCategory = "dev-haskell"}, cabalPkgName = PackageName "foo-bar2"}, pkgVersion = Version {versionNumber = [3,0,0], versionChar = Just 'b', versionSuffix = [RC 2], versionRevision = 1}})
+-- Just (PackageId {pkgName = PackageName {category = Category {unCategory = "dev-haskell"}, cabalPkgName = PackageName "foo-bar2"}, pkgVersion = Version {versionNumber = [3,0,0], versionChar = Just 'b', versionSuffix = [RC 2], versionRevision = 1}})
 filePathToPackageId :: Category -> FilePath -> Maybe PackageId
 filePathToPackageId cat fp =
   case explicitEitherParsec parser fp of

--- a/Status.hs
+++ b/Status.hs
@@ -111,7 +111,7 @@ status verbosity portdir overlaydir repoContext = do
             where Just cabal_p = toCabalPackageId p -- lame doubleconv
                   ebuild_path = packageIdToFilePath p
         mk_fake_ee :: [PackageId] -> (PackageName, [ExistingEbuild])
-        mk_fake_ee ~pkgs@(p:_) = (packageId p, map p_to_ee pkgs)
+        mk_fake_ee ~pkgs@(p:_) = (pkgName p, map p_to_ee pkgs)
 
         map_diff = Map.differenceWith (\le re -> Just $ foldr (List.deleteBy (Cabal.equating ebuildId)) le re)
         hack = (( -- We merge package names as we do case-insensitive match.
@@ -135,7 +135,7 @@ type EMap = Map PackageName [ExistingEbuild]
 
 lookupEbuildWith :: EMap -> PackageId -> Maybe ExistingEbuild
 lookupEbuildWith overlay pkgid = do
-  ebuilds <- Map.lookup (packageId pkgid) overlay
+  ebuilds <- Map.lookup (pkgName pkgid) overlay
   List.find (\e -> ebuildId e == pkgid) ebuilds
 
 runStatus :: Cabal.Verbosity -> FilePath -> FilePath -> StatusDirection -> [String] -> CabalInstall.RepoContext -> IO ()


### PR DESCRIPTION
See the commit message for more details.

This is a basic attempt at advising the user if a certain package is considered to be actively maintained in `::gentoo`. That list is currently hard-coded and purposely avoids advising to bump every package that exists in `::gentoo` if it is bumped in `::haskell`, and this is for the purpose of stability.

Hackport will check to see if it is operating inside `::gentoo` before emitting the 'please sync' message. Other than that there are no checks, and it will ask every user - whether using a private repo or a local `::haskell` repo - to consider syncing their version bump to ::gentoo.

Currently it prints the message in bold yellow, with the package category and package name pretty-printed in bold purple (magenta).

This is a basic, largely hard-coded attempt and I appreciate comments and suggestions to rework this if there is a better way.

Lastly: this commit only makes sense if we want to maintain `::gentoo` and `::haskell` in these ways: the former as a relatively stable place for somewhat common haskell packages useful to the broader community, like `xmonad` and `pandoc`, and the latter as a broader, faster-moving, more bleeding-edge testing ground for haskell packages.