### PR TITLE
Merge.hs: add concurrency where appropriate

### DIFF
--- a/hackport.cabal
+++ b/hackport.cabal
@@ -16,10 +16,10 @@ source-repository head
   location: git://github.com/gentoo-haskell/hackport.git
 
 Executable    hackport
-  ghc-options: -Wall
+  ghc-options: -Wall -threaded +RTS -N -RTS
   ghc-prof-options: -caf-all -auto-all -rtsopts
   Main-Is:    Main.hs
-  Default-Language: Haskell98
+  Default-Language: Haskell2010
   Hs-Source-Dirs:
       .,
       cabal,


### PR DESCRIPTION
**Long story short:** run `pkgcheck` and `repoman` concurrently using `Control.Concurrent.forkIO` and `MVar`s.

**Long story:**

**EDIT:** the below commentary is superseded by [a newer comment](https://github.com/gentoo-haskell/hackport/pull/73#issuecomment-669054691).

The recent addition of `pkgcheck scan` slowed things down by about six seconds on my machine. Given a `hackport merge` can already take nearly a minute waiting for `repoman` to finish its checks, I don't want to make it even slower. 

Short of removing `pkgcheck` (which I'd rather not do due to its extra checks, and that it is the same tool running CI on `::gentoo` GitHub), and since we can't remove `repoman` either since `pkgcheck` doesn't implement all of its checks, the option is to run `pkgcheck` and `repoman` in parallel. This commit tries to do this. It operates as follows:

`pkgcheck` is expected to always return well before `repoman`, so we first fork `repoman` off into its own thread. `pkgcheck` will then run in the main thread. `repoman` will put its exit code into an `MVar`, and (just as is the behaviour without this patch) will print a message warning the user of a repoman failure if it returns `ExitFailure`.

The results are more or less expected: however long `pkgcheck` takes is taken off the total run time - about six seconds on my machine, or thereabouts.

The output slightly misleading: it will notify the user that both `pkgcheck scan` and `repoman full --include-dev` are being run, but shortly after the `RepoMan scours the neighborhood...` line, `pkgcheck` - being much quicker than `repoman` - returns the results of its checks. ~~I am personally fine with this, but that may just be me.~~ It then _appears_ to hang until `repoman` returns its results much later.

Interlacing helpful messages for the user will work, but will be misleading when the runtime is not threaded. So I'd like to spend some more time on this.

Thank you in advance!