### PR TITLE
Merge.hs: correctly handle USE_EXPANDs

### DIFF
--- a/Merge.hs
+++ b/Merge.hs
@@ -412,8 +412,12 @@ mergeGenericPackageDescription verbosity overlayPath cat pkgGenericDesc fetch us
                        Just ucf -> (\e -> e { E.used_options  = E.used_options e ++ [("flags", ucf)] }))
                $ C2E.cabal2ebuild cat (Merge.packageDescription pkgDesc)
 
-  let iuse_flag_descs = (\f -> f { Cabal.flagName = Cabal.mkFlagName . cfn_to_iuse . Cabal.unFlagName . Cabal.flagName $ f }) <$> active_flag_descs
-    in mergeEbuild verbosity existing_meta pkgdir ebuild iuse_flag_descs
+  let active_flag_descs_renamed =
+        (\f -> f { Cabal.flagName = Cabal.mkFlagName . cfn_to_iuse . Cabal.unFlagName
+                   . Cabal.flagName $ f }) <$> active_flag_descs
+  iuse_flag_descs <- Merge.dropIfUseExpands active_flag_descs_renamed
+  mergeEbuild verbosity existing_meta pkgdir ebuild iuse_flag_descs
+
   when fetch $ do
     let cabal_pkgId = Cabal.packageId (Merge.packageDescription pkgDesc)
         norm_pkgName = Cabal.packageName (Portage.normalizeCabalPackageId cabal_pkgId)

--- a/tests/Merge/UtilsSpec.hs
+++ b/tests/Merge/UtilsSpec.hs
@@ -7,6 +7,7 @@ import           QuickCheck.Instances
 
 import           Control.Applicative (liftA2)
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (catMaybes)
 import qualified Data.List as L
 
 import           Error
@@ -118,3 +119,16 @@ spec = do
       \name desc -> metaFlags [(Cabal.emptyFlag (Cabal.mkFlagName name))
                                 { Cabal.flagDescription = desc }] ==
                     Map.fromList [(mangle_iuse name,desc)]
+
+  describe "dropIfUseExpand" $ do
+    it "drops a USE flag if it is a USE_EXPAND, otherwise preserves it" $ do
+      let use_expands = ["cpu_flags_x86","cpu_flags_arm"]
+          flags       = Cabal.emptyFlag . Cabal.mkFlagName <$>
+                        [ "cpu_flags_x86_sse4_2"
+                        , "foo"
+                        , "bar"
+                        , "baz"
+                        , "cpu_flags_arm_v8"
+                        ]
+      Cabal.unFlagName . Cabal.flagName <$> catMaybes (dropIfUseExpand use_expands <$> flags)
+        `shouldBe` ["foo","bar","baz"]


### PR DESCRIPTION
Opening for review if anyone is interested, and to check the GitHub Actions CI against the various GHC versions. Assuming no issues I intend to push this change shortly.

This commit teaches hackport to recognise `USE_EXPAND`s and ignore their writing to the `metadata.xml`.

A summary of the changes:

**Merge.hs**

- `active_flag_descs_renamed` is simply `active_flag_descs` but with their `Cabal.flagName` replaced with any user-specified flag renames, if applicable.
- `iuse_flag_descs` is `active_flag_descs_renamed` with `USE_EXPAND`s stripped away.

**Merge/Utils.hs**

- Three functions have been added, one of which is exported for use in `Merge.hs` and another pure function exported to allow for testing via the test suite.
- `getUseExpands` returns a list of `USE_EXPAND`s currently found in `$(portageq get_repo_path / gentoo)/profiles/desc/`.
- `dropIfUseExpand` is a pure function which returns `Just <flag>` if the flag is _not_ a `USE_EXPAND`, otherwise it returns `Nothing`. We test this function in the `spec` test suite.
- `dropIfUseExpands` maps `dropIfUseExpand` over a list returned by `getUseExpands` and a list of `Cabal.PackageFlag`s. It returns a list of values of all `Just`s and discards all `Nothing`s. In plain English: return the flags which aren't `USE_EXPAND`s as a list of `Cabal.PackageFlag`s.

**Merge/UtilsSpec.hs**

- Test the functioning of `dropIfUseExpand` by mapping it over predefined lists of `USE_EXPAND`s and `USE` flags.

Closes: https://github.com/gentoo-haskell/hackport/issues/75