### PR TITLE
hackport.cabal: Add default RTS flag

### DIFF
--- a/hackport.cabal
+++ b/hackport.cabal
@@ -16,7 +16,7 @@ source-repository head
   location: git://github.com/gentoo-haskell/hackport.git
 
 Executable    hackport
-  ghc-options: -Wall -threaded +RTS -N -RTS
+  ghc-options: -Wall -threaded +RTS -N -RTS -with-rtsopts=-N
   ghc-prof-options: -caf-all -auto-all -rtsopts
   Main-Is:    Main.hs
   Default-Language: Haskell2010


### PR DESCRIPTION
This will make `hackport` use the maximum number of cores by default, instead of having to invoke `hackport +RTS -N -RTS ...`

See: https://downloads.haskell.org/ghc/latest/docs/html/users_guide/phases.html#ghc-flag--with-rtsopts=%E2%9F%A8opts%E2%9F%A9