### PR TITLE
Teach hackport to handle global USE flags

### DIFF
--- a/Portage/Metadata.hs
+++ b/Portage/Metadata.hs
@@ -9,6 +9,7 @@ module Portage.Metadata
         ( Metadata(..)
         , metadataFromFile
         , pureMetadataFromFile
+        , stripGlobalUseFlags -- exported for hspec
         , prettyPrintFlags -- exported for hspec
         , prettyPrintFlagsHuman
         , makeDefaultMetadata
@@ -76,20 +77,31 @@ parseMetadata xml =
                       in Map.fromList $ zip z b
                   }
 
+-- | Remove global @USE@ flags from the flags 'Map.Map', as these should not be
+-- within the local @metadata.xml@. For now, this is manually specified rather than
+-- parsing @use.desc@.
+stripGlobalUseFlags :: Map.Map String String -> Map.Map String String
+stripGlobalUseFlags m = foldr1 Map.intersection (Map.delete <$> globals <*> [m])
+  where
+    globals = [ "debug"
+              , "examples"
+              , "static"
+              ]
+
 -- | Pretty print as valid XML a list of flags and their descriptions
 -- from a given 'Map.Map'.
 prettyPrintFlags :: Map.Map String String -> [String]
 prettyPrintFlags m = (\(name,description) ->
                         "\t\t<flag name=\"" ++ name ++ "\">" ++
                         (L.intercalate " " . lines $ description) ++ "</flag>")
-                     <$> Map.toAscList m
+                     <$> (Map.toAscList . stripGlobalUseFlags $ m)
 
 -- | Pretty print a human-readable list of flags and their descriptions
 -- from a given 'Map.Map'.
 prettyPrintFlagsHuman :: Map.Map String String -> [String]
 prettyPrintFlagsHuman m = (\(name,description) -> A.bold (name ++ ": ") ++
                             (L.intercalate " " . lines $ description))
-                          <$> Map.toAscList m
+                          <$> (Map.toAscList . stripGlobalUseFlags $ m)
                           
 -- | A minimal metadata for use as a fallback value.
 makeMinimalMetadata :: Metadata

--- a/tests/Merge/UtilsSpec.hs
+++ b/tests/Merge/UtilsSpec.hs
@@ -102,6 +102,14 @@ spec = do
           then [flag]
           else [prefix ++ '-':flag]
 
+  describe "squash_debug" $ do
+    it "squashes debug-related flags under the debug global USE flag" $ do
+      squash_debug "use-debug-foo" `shouldBe` "debug"
+      squash_debug "debug-foo" `shouldBe` "debug"
+      squash_debug "foo-debugger" `shouldBe` "debug"
+    it "ignores debug-unrelated flags" $ do
+      squash_debug "foo-bar" `shouldBe` "foo-bar"
+
   describe "mangle_iuse" $ do
     prop "converts underscores (_) into hyphens (-) and drops with/use prefixes" $ do
         \a -> mangle_iuse a == drop_prefix (map (\f -> if f == '_' then '-' else f) a)

--- a/tests/Merge/UtilsSpec.hs
+++ b/tests/Merge/UtilsSpec.hs
@@ -110,9 +110,20 @@ spec = do
     it "ignores debug-unrelated flags" $ do
       squash_debug "foo-bar" `shouldBe` "foo-bar"
 
+  describe "convert_underscores" $ do
+    it "converts underscores (_) into hyphens (-)" $ do
+      convert_underscores "foo_bar" `shouldBe` "foo-bar"
+    it "ignores mangling of separators other than underscores" $ do
+      convert_underscores "foo-bar" `shouldBe` "foo-bar"
+    it "ignores mangling of characters which are not separators" $ do
+      convert_underscores "foobar" `shouldBe` "foobar"
+
   describe "mangle_iuse" $ do
-    prop "converts underscores (_) into hyphens (-) and drops with/use prefixes" $ do
-        \a -> mangle_iuse a == drop_prefix (map (\f -> if f == '_' then '-' else f) a)
+    it "performs all IUSE mangling" $ do
+      mangle_iuse "use_foo_bar" `shouldBe` "foo-bar"
+      mangle_iuse "with-baz-quux" `shouldBe` "baz-quux"
+      mangle_iuse "use_debugging-symbols" `shouldBe` "debug"
+      mangle_iuse "foo-bar-baz_quux" `shouldBe` "foo-bar-baz-quux"
 
   describe "to_unstable" $ do
     prop "creates an unstable keyword from a stable keyword, or preserves a mask" $ do

--- a/tests/Portage/MetadataSpec.hs
+++ b/tests/Portage/MetadataSpec.hs
@@ -20,6 +20,17 @@ spec = do
       let flags = Map.singleton "name" "description"
       pureMetadataFromFile (makeDefaultMetadata flags) `shouldBe` Just (makeMinimalMetadata { metadataUseFlags = flags })
 
+  describe "stripGlobalUseFlags" $ do
+    it "should remove specified global USE flags from the metadata.xml" $ do
+      stripGlobalUseFlags (Map.singleton "debug" "description") `shouldBe` Map.empty
+      stripGlobalUseFlags (Map.singleton "examples" "description") `shouldBe` Map.empty
+      stripGlobalUseFlags (Map.singleton "static" "description") `shouldBe` Map.empty
+    prop "should ignore USE flags that are not specified as global" $ do
+      \name description -> stripGlobalUseFlags (Map.singleton name description) ==
+                           if name `elem` ["debug","examples","static"]
+                           then Map.empty
+                           else Map.singleton name description
+
   describe "prettyPrintFlags" $ do
     prop "should correctly format a single USE flag name with its description" $ do
       \name description -> prettyPrintFlags (Map.singleton name description) ==


### PR DESCRIPTION
Currently, this is implemented without parsing `use.desc`. The reason for this is that I'm unsure if this will cause issues where a local USE flag, auto-generated from the package's cabal flag, has a different meaning to that of the global USE flag whose name it shares.

This PR also squashes any flag names with the word "debug" in it down to just "debug", so that it falls under the "debug" global USE flag.

Open to critique and discussion to improve, postpone or altogether abandon this change.

**Update 1**
This PR now also contains a rewrite of the `drop_prefix` function. See the commit message for details.