### PR TITLE
Portage/EBuild.hs: add khumba.net to HTTP-only homepage list

### DIFF
--- a/Portage/EBuild.hs
+++ b/Portage/EBuild.hs
@@ -183,6 +183,7 @@ toHttps x =
     -- add to this list with any non https-aware websites
     httpOnlyHomepages = Just <$> [ "leksah.org"
                                  , "darcs.net"
+                                 , "khumba.net"
                                  ]
 
 -- | Sort IUSE alphabetically

--- a/tests/Portage/EBuildSpec.hs
+++ b/tests/Portage/EBuildSpec.hs
@@ -33,6 +33,7 @@ spec = do
     it "should not convert whitelisted http-only homepages into https homepages" $ do
       toHttps "http://leksah.org" `shouldBe` "http://leksah.org"
       toHttps "http://darcs.net/" `shouldBe` "http://darcs.net/"
+      toHttps "http://khumba.net/" `shouldBe` "http://khumba.net/"
     it "should otherwise convert all homepages into https-aware homepages" $ do
       toHttps "http://pandoc.org" `shouldBe` "https://pandoc.org"
       toHttps "http://www.yesodweb.com/" `shouldBe` "https://www.yesodweb.com/"


### PR DESCRIPTION
Hello,

My personal site is HTTP-only, and is pointed to by a few packages (goatee* in the main tree, hoppy* and qtah* in my overlay).  May I please add my site to the HTTP blacklist so that the URL doesn't get rewritten to HTTPS?

Thanks.