### PR TITLE
Portage/GHCCore.hs: Uncomment various lines

### DIFF
--- a/Portage/GHCCore.hs
+++ b/Portage/GHCCore.hs
@@ -222,7 +222,7 @@ ghc8104_pkgs =
   , p "deepseq" [1,4,4,0] -- used by time
   , p "directory" [1,3,6,0]
   , p "filepath" [1,4,2,1]
---  , p "exceptions [0,10,4] -- used by haskeline, package is upgradeable 
+  , p "exceptions" [0,10,4] -- used by haskeline, package is upgradeable
   , p "ghc-boot" [8,10,4]
   , p "ghc-boot-th" [8,10,4]
   , p "ghc-compact" [0,1,0,0]
@@ -232,14 +232,14 @@ ghc8104_pkgs =
 --  , p "haskeline" [0,8,0,1]  package is upgradeable
   , p "hpc" [0,6,1,0] -- used by libghc
   , p "integer-gmp" [1,0,3,0]
-  --  , p "mtl" [2,2,2]  package is upgradeable(?)
+  , p "mtl" [2,2,2] -- package is upgradeable(?)
   --  , p "parsec" [3,1,14,0]  package is upgradeable(?)
   , p "pretty" [1,1,3,6]
   , p "process" [1,6,9,0]
   --  , p "stm" [2,5,0,0]  package is upgradeable(?)
   , p "template-haskell" [2,16,0,0] -- used by libghc
   -- , p "terminfo" [0,4,1,4]
-  -- , p "text" [1,2,4,1] dependency of Cabal library
+  , p "text" [1,2,4,1] -- dependency of Cabal library
   , p "time" [1,9,3,0] -- used by unix, directory, hpc, ghc. unsafe to upgrade
   , p "transformers" [0,5,6,2] -- used by libghc
   , p "unix" [2,7,2,2]
@@ -257,7 +257,7 @@ ghc8101_pkgs =
   , p "deepseq" [1,4,4,0] -- used by time
   , p "directory" [1,3,6,0]
   , p "filepath" [1,4,2,1]
---  , p "exceptions [0,10,4] -- used by haskeline, package is upgradeable 
+  , p "exceptions" [0,10,4] -- used by haskeline, package is upgradeable
   , p "ghc-boot" [8,10,1]
   , p "ghc-boot-th" [8,10,1]
   , p "ghc-compact" [0,1,0,0]
@@ -267,14 +267,14 @@ ghc8101_pkgs =
 --  , p "haskeline" [0,8,0,0]  package is upgradeable
   , p "hpc" [0,6,1,0] -- used by libghc
   , p "integer-gmp" [1,0,3,0]
-  --  , p "mtl" [2,2,2]  package is upgradeable(?)
+  , p "mtl" [2,2,2] -- package is upgradeable(?)
   --  , p "parsec" [3,1,14,0]  package is upgradeable(?)
   , p "pretty" [1,1,3,6]
   , p "process" [1,6,8,2]
   --  , p "stm" [2,5,0,0]  package is upgradeable(?)
   , p "template-haskell" [2,16,0,0] -- used by libghc
   -- , p "terminfo" [0,4,1,4]
-  -- , p "text" [1,2,3,2] dependency of Cabal library
+  , p "text" [1,2,3,2] -- dependency of Cabal library
   , p "time" [1,9,3,0] -- used by unix, directory, hpc, ghc. unsafe to upgrade
   , p "transformers" [0,5,6,2] -- used by libghc
   , p "unix" [2,7,2,2]
@@ -300,14 +300,14 @@ ghc884_pkgs =
 --  , p "haskeline" [0,7,5,0]  package is upgradeable
   , p "hpc" [0,6,0,3] -- used by libghc
   , p "integer-gmp" [1,0,2,0]
-  --  , p "mtl" [2,2,2]  package is upgradeable(?)
+  , p "mtl" [2,2,2] -- package is upgradeable(?)
   --  , p "parsec" [3,1,14,0]  package is upgradeable(?)
   , p "pretty" [1,1,3,6]
   , p "process" [1,6,9,0]
   --  , p "stm" [2,5,0,0]  package is upgradeable(?)
   , p "template-haskell" [2,15,0,0] -- used by libghc
   -- , p "terminfo" [0,4,1,4]
-  -- , p "text" [1,2,4,0] dependency of Cabal library
+  , p "text" [1,2,4,0] -- dependency of Cabal library
   , p "time" [1,9,3,0] -- used by unix, directory, hpc, ghc. unsafe to upgrade
   , p "transformers" [0,5,6,2] -- used by libghc
   , p "unix" [2,7,2,2]
@@ -333,14 +333,14 @@ ghc883_pkgs =
 --  , p "haskeline" [0,7,5,0]  package is upgradeable
   , p "hpc" [0,6,0,3] -- used by libghc
   , p "integer-gmp" [1,0,2,0]
-  --  , p "mtl" [2,2,2]  package is upgradeable(?)
+  , p "mtl" [2,2,2] -- package is upgradeable(?)
   --  , p "parsec" [3,1,14,0]  package is upgradeable(?)
   , p "pretty" [1,1,3,6]
   , p "process" [1,6,8,0]
   --  , p "stm" [2,5,0,0]  package is upgradeable(?)
   , p "template-haskell" [2,15,0,0] -- used by libghc
   -- , p "terminfo" [0,4,1,4]
-  -- , p "text" [1,2,4,0] dependency of Cabal library
+  , p "text" [1,2,4,0] -- dependency of Cabal library
   , p "time" [1,9,3,0] -- used by unix, directory, hpc, ghc. unsafe to upgrade
   , p "transformers" [0,5,6,2] -- used by libghc
   , p "unix" [2,7,2,2]
@@ -366,14 +366,14 @@ ghc881_pkgs =
 --  , p "haskeline" [0,7,4,3]  package is upgradeable
   , p "hpc" [0,6,0,3] -- used by libghc
   , p "integer-gmp" [1,0,2,0]
-  --  , p "mtl" [2,2,2]  package is upgradeable(?)
+  , p "mtl" [2,2,2] -- package is upgradeable(?)
   --  , p "parsec" [3,1,14,0]  package is upgradeable(?)
   , p "pretty" [1,1,3,6]
   , p "process" [1,6,5,1]
   --  , p "stm" [2,5,0,0]  package is upgradeable(?)
   , p "template-haskell" [2,15,0,0] -- used by libghc
   -- , p "terminfo" [0,4,1,4]
-  -- , p "text" [1,2,4,0] dependency of Cabal library
+  , p "text" [1,2,4,0] -- dependency of Cabal library
   , p "time" [1,9,3,0] -- used by unix, directory, hpc, ghc. unsafe to upgrade
   , p "transformers" [0,5,6,2] -- used by libghc
   , p "unix" [2,7,2,2]
@@ -399,14 +399,14 @@ ghc865_pkgs =
 --  , p "haskeline" [0,7,4,3]  package is upgradeable
   , p "hpc" [0,6,0,3] -- used by libghc
   , p "integer-gmp" [1,0,2,0]
-  --  , p "mtl" [2,2,2]  package is upgradeable(?)
+  , p "mtl" [2,2,2] -- package is upgradeable(?)
   --  , p "parsec" [3,1,13,0]  package is upgradeable(?)
   , p "pretty" [1,1,3,6]
   , p "process" [1,6,5,0]
   --  , p "stm" [2,5,0,0]  package is upgradeable(?)
   , p "template-haskell" [2,14,0,0] -- used by libghc
   -- , p "terminfo" [0,4,1,2]
-  -- , p "text" [1,2,3,1] dependency of Cabal library
+  , p "text" [1,2,3,1] -- dependency of Cabal library
   , p "time" [1,8,0,2] -- used by unix, directory, hpc, ghc. unsafe to upgrade
   , p "transformers" [0,5,6,2] -- used by libghc
   , p "unix" [2,7,2,2]
@@ -432,14 +432,14 @@ ghc863_pkgs =
 --  , p "haskeline" [0,7,4,3]  package is upgradeable
   , p "hpc" [0,6,0,3] -- used by libghc
   , p "integer-gmp" [1,0,2,0]
-  --  , p "mtl" [2,2,2]  package is upgradeable(?)
+  , p "mtl" [2,2,2] -- package is upgradeable(?)
   --  , p "parsec" [3,1,13,0]  package is upgradeable(?)
   , p "pretty" [1,1,3,6]
   , p "process" [1,6,3,0]
   --  , p "stm" [2,5,0,0]  package is upgradeable(?)
   , p "template-haskell" [2,14,0,0] -- used by libghc
   -- , p "terminfo" [0,4,1,2]
-  -- , p "text" [1,2,3,1] dependency of Cabal library
+  , p "text" [1,2,3,1] -- dependency of Cabal library
   , p "time" [1,8,0,2] -- used by unix, directory, hpc, ghc. unsafe to upgrade
   , p "transformers" [0,5,5,0] -- used by libghc
   , p "unix" [2,7,2,2]
@@ -465,14 +465,14 @@ ghc843_pkgs =
 --  , p "haskeline" [0,7,4,2]  package is upgradeable
   , p "hpc" [0,6,0,3] -- used by libghc
   , p "integer-gmp" [1,0,2,0]
-  --  , p "mtl" [2,2,2]  package is upgradeable(?)
+  , p "mtl" [2,2,2] -- package is upgradeable(?)
   --  , p "parsec" [3,1,13,0]  package is upgradeable(?)
   , p "pretty" [1,1,3,6]
   , p "process" [1,6,3,0]
   --  , p "stm" [2,4,5,0]  package is upgradeable(?)
   , p "template-haskell" [2,13,0,0] -- used by libghc
   -- , p "terminfo" [0,4,1,1]
-  -- , p "text" [1,2,3,0]
+  , p "text" [1,2,3,0]
   , p "time" [1,8,0,2] -- used by unix, directory, hpc, ghc. unsafe to upgrade
   , p "transformers" [0,5,5,0] -- used by libghc
   , p "unix" [2,7,2,2]

--- a/Portage/GHCCore.hs
+++ b/Portage/GHCCore.hs
@@ -233,7 +233,7 @@ ghc8104_pkgs =
   , p "hpc" [0,6,1,0] -- used by libghc
   , p "integer-gmp" [1,0,3,0]
   , p "mtl" [2,2,2] -- package is upgradeable(?)
-  --  , p "parsec" [3,1,14,0]  package is upgradeable(?)
+  , p "parsec" [3,1,14,0]  -- package is upgradeable(?)
   , p "pretty" [1,1,3,6]
   , p "process" [1,6,9,0]
   --  , p "stm" [2,5,0,0]  package is upgradeable(?)
@@ -268,7 +268,7 @@ ghc8101_pkgs =
   , p "hpc" [0,6,1,0] -- used by libghc
   , p "integer-gmp" [1,0,3,0]
   , p "mtl" [2,2,2] -- package is upgradeable(?)
-  --  , p "parsec" [3,1,14,0]  package is upgradeable(?)
+  , p "parsec" [3,1,14,0] -- package is upgradeable(?)
   , p "pretty" [1,1,3,6]
   , p "process" [1,6,8,2]
   --  , p "stm" [2,5,0,0]  package is upgradeable(?)


### PR DESCRIPTION
Related to https://github.com/gentoo-haskell/hackport/issues/103

There seem to be a number of lines in this file that are commented, and it's not clear why. I ran into the following error which seems to be cleared up by uncommenting some of these lines:

```
$ hackport merge dhall-1.38.1
rejecting dep: ghc-8.4.3 as ["exceptions >=0.8.3 && <0.11","mtl >=2.2.1 && <2.3","text >=0.11.1.0 && <1.3"] were not found.
rejecting dep: ghc-8.6.3 as ["exceptions >=0.8.3 && <0.11","mtl >=2.2.1 && <2.3","text >=0.11.1.0 && <1.3"] were not found.
rejecting dep: ghc-8.6.5 as ["exceptions >=0.8.3 && <0.11","mtl >=2.2.1 && <2.3","text >=0.11.1.0 && <1.3"] were not found.
rejecting dep: ghc-8.8.1 as ["exceptions >=0.8.3 && <0.11","mtl >=2.2.1 && <2.3","text >=0.11.1.0 && <1.3"] were not found.
rejecting dep: ghc-8.8.3 as ["exceptions >=0.8.3 && <0.11","mtl >=2.2.1 && <2.3","text >=0.11.1.0 && <1.3"] were not found.
rejecting dep: ghc-8.8.4 as ["exceptions >=0.8.3 && <0.11","mtl >=2.2.1 && <2.3","text >=0.11.1.0 && <1.3"] were not found.
rejecting dep: ghc-8.10.1 as ["exceptions >=0.8.3 && <0.11","mtl >=2.2.1 && <2.3","text >=0.11.1.0 && <1.3"] were not found.
rejecting dep: ghc-8.10.4 as ["exceptions >=0.8.3 && <0.11","mtl >=2.2.1 && <2.3","text >=0.11.1.0 && <1.3"] were not found.
rejecting dep: ghc-9.0.2 as ["template-haskell >=2.13.0.0 && <2.17"] were not found.
hackport: mergeGenericPackageDescription: failed to find suitable GHC for dhall
  You can try to merge the package manually:
  $ cabal unpack dhall
  $ cd dhall*/
  # fix dhall.cabal
  $ hackport make-ebuild dev-lang dhall.cabal

CallStack (from HasCallStack):
  error, called at Merge.hs:219:29 in main:Merge
```

After https://github.com/gentoo-haskell/hackport/pull/104/commits/935130c1df9ed0fd8afd1b43c74c7e8a0cc7835e , it seems to work as expected. I also have not noticed any problematic side effects from the changes:

```
$ hackport merge dhall-1.38.1
rejecting dep: ghc-8.4.3 as ["exceptions >=0.8.3 && <0.11"] were not found.
rejecting dep: ghc-8.6.3 as ["exceptions >=0.8.3 && <0.11"] were not found.
rejecting dep: ghc-8.6.5 as ["exceptions >=0.8.3 && <0.11"] were not found.
rejecting dep: ghc-8.8.1 as ["exceptions >=0.8.3 && <0.11"] were not found.
rejecting dep: ghc-8.8.3 as ["exceptions >=0.8.3 && <0.11"] were not found.
rejecting dep: ghc-8.8.4 as ["exceptions >=0.8.3 && <0.11"] were not found.
accepting dep: ghc-8.10.1
Accepted depends: ["Diff >=0.2 && <0.5","aeson >=1.0.0.0 &&
<1.6","aeson-pretty <0.9","ansi-terminal >=0.6.3.1 && <0.12","atomic-write
>=0.2.0.7 && <0.3","case-insensitive <1.3","cborg >=0.2.0.0 &&
<0.3","cborg-json >=0.2.2.0 && <0.3","contravariant <1.6","cryptonite >=0.23
&& <1.0","data-fix <0.4","dotgen >=0.4.2 && <0.5","either >=5 && <5.1","half
>=0.2.2.3 && <0.4","hashable >=1.2 && <1.4","haskeline >=0.7.2.1 &&
<0.9","http-client >=0.5.0 && <0.8","http-client-tls >=0.2.0 &&
<0.4","http-types >=0.7.0 && <0.13","lens-family-core >=1.0.0 &&
<2.2","megaparsec >=7 && <9.1","memory >=0.14 && <0.17","mmorph
<1.2","network-uri >=2.6 && <2.7","optparse-applicative >=0.14.0.0 &&
<0.17","parser-combinators","parsers >=0.12.4 && <0.13","pretty-simple
<4.1","prettyprinter >=1.5.1 && <1.8","prettyprinter-ansi-terminal >=1.1.1 &&
<1.2","profunctors >=3.1.2 && <5.7","repline >=0.4.0.0 && <0.5","scientific
>=0.3.0.0 && <0.4","serialise >=0.2.0.0 && <0.3","text-manipulate >=0.2.0.1 &&
<0.4","th-lift-instances >=0.1.13 && <0.2","transformers-compat >=0.6.2 &&
<0.7","unordered-containers >=0.1.3.0 && <0.3","uri-encode <1.6","vector
>=0.11.0.0 && <0.13"]
Skipped depends: ["base","dhall","base >=4.11.0.0 && <5","bytestring
<0.12","containers >=0.5.8.0 && <0.7","deepseq <1.5","directory >=1.3.0.0 &&
<1.4","exceptions >=0.8.3 && <0.11","filepath >=1.4 && <1.5","mtl >=2.2.1 &&
<2.3","template-haskell >=2.13.0.0 && <2.17","text >=0.11.1.0 &&
<1.3","transformers >=0.2.0.0 && <0.6"]
Dead flags: []
Dropped flags: ["cross"]
Active flags: ["with-http","use-http-client-tls"]
Irrelevant flags: []
Current keywords: Just ["~amd64","~x86"] -> ["~amd64","~x86"]
Current license: Just "BSD" -> Right "BSD"
Writing dhall-1.38.1.ebuild
Recalculating digests...
Running repoman full --include-dev and pkgcheck scan...
```