### PR TITLE
Portage.EBuild: Drop khumba.net from HTTP-only site list

### DIFF
--- a/src/Portage/EBuild.hs
+++ b/src/Portage/EBuild.hs
@@ -177,7 +177,6 @@ toHttps x =
     -- add to this list with any non https-aware websites
     httpOnlyHomepages = Just <$> [ "leksah.org"
                                  , "darcs.net"
-                                 , "khumba.net"
                                  ]
 
 -- | Sort IUSE alphabetically

--- a/tests/spec/Portage/EBuildSpec.hs
+++ b/tests/spec/Portage/EBuildSpec.hs
@@ -26,7 +26,6 @@ spec = do
     it "should not convert whitelisted http-only homepages into https homepages" $ do
       toHttps "http://leksah.org" `shouldBe` "http://leksah.org"
       toHttps "http://darcs.net/" `shouldBe` "http://darcs.net/"
-      toHttps "http://khumba.net/" `shouldBe` "http://khumba.net/"
     it "should otherwise convert all homepages into https-aware homepages" $ do
       toHttps "http://pandoc.org" `shouldBe` "https://pandoc.org"
       toHttps "http://www.yesodweb.com/" `shouldBe` "https://www.yesodweb.com/"


### PR DESCRIPTION
I've got with the times and have HTTPS on my site now.  Thanks for understanding before.