### PR TITLE
Error.hs: removing Typeable derivation

### DIFF
--- a/src/Error.hs
+++ b/src/Error.hs
@@ -7,7 +7,6 @@ module Error
     , catch
     ) where
 
-import Data.Typeable
 import Control.Exception
 
 -- | Type holding all of the 'HackPortError' constructors.
@@ -32,7 +31,7 @@ data HackPortError
     -- | WrongCacheVersion
     -- | InvalidCache
     | InvalidServer String
-    deriving (Typeable
+    deriving (
              , Show
              , Eq -- ^ needed for spec test-suite
              )

--- a/src/Error.hs
+++ b/src/Error.hs
@@ -32,7 +32,7 @@ data HackPortError
     -- | InvalidCache
     | InvalidServer String
     deriving (
-             , Show
+             Show
              , Eq -- ^ needed for spec test-suite
              )
 


### PR DESCRIPTION
Hackport won't compile with ghc-9.12 due to the addition of -Wderiving-typeable to -Wall
https://downloads.haskell.org/ghc/latest/docs/users_guide/9.12.1-notes.html#compiler
Anyhow, Typeable is automatically derived for all types since ghc-7.10
https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#ghc-flag-Wderiving-typeable